### PR TITLE
Cleanly exit logger

### DIFF
--- a/semmc-ppc/semmc-ppc.cabal
+++ b/semmc-ppc/semmc-ppc.cabal
@@ -146,6 +146,7 @@ executable semmc-ppc-synthdemo
                  , elf-edit
                  , optparse-applicative
                  , async
+                 , unliftio
 
 executable semmc-ppc-genbase
   default-language: Haskell2010


### PR DESCRIPTION
Removes `BlockedIndefinitelyOnSTM` exception which prematurely kills `synth-demo`.