### PR TITLE
WIP - Updated LI semantics and reran genbase

### DIFF
--- a/semmc-ppc/data/32/base/ADD4.sem
+++ b/semmc-ppc/data/32/base/ADD4.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvadd rA rB))

--- a/semmc-ppc/data/32/base/ADD4o.sem
+++ b/semmc-ppc/data/32/base/ADD4o.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/ADDC.sem
+++ b/semmc-ppc/data/32/base/ADDC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/ADDCo.sem
+++ b/semmc-ppc/data/32/base/ADDCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/ADDE.sem
+++ b/semmc-ppc/data/32/base/ADDE.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/ADDEo.sem
+++ b/semmc-ppc/data/32/base/ADDEo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/ADDIC.sem
+++ b/semmc-ppc/data/32/base/ADDIC.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER si rA 'IP))
+  ('XER rA si 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/ADDICo.sem
+++ b/semmc-ppc/data/32/base/ADDICo.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER si rA 'IP))
+  ('XER 'CR 'XER rA si 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/AND.sem
+++ b/semmc-ppc/data/32/base/AND.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvand rS rB))

--- a/semmc-ppc/data/32/base/ANDC.sem
+++ b/semmc-ppc/data/32/base/ANDC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvand

--- a/semmc-ppc/data/32/base/ANDCo.sem
+++ b/semmc-ppc/data/32/base/ANDCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/ANDo.sem
+++ b/semmc-ppc/data/32/base/ANDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/CMPB.sem
+++ b/semmc-ppc/data/32/base/CMPB.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (concat

--- a/semmc-ppc/data/32/base/DIVW.sem
+++ b/semmc-ppc/data/32/base/DIVW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvsdiv rA rB))

--- a/semmc-ppc/data/32/base/DIVWU.sem
+++ b/semmc-ppc/data/32/base/DIVWU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvudiv rA rB))

--- a/semmc-ppc/data/32/base/DIVWUo.sem
+++ b/semmc-ppc/data/32/base/DIVWUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/DIVWo.sem
+++ b/semmc-ppc/data/32/base/DIVWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/EQV.sem
+++ b/semmc-ppc/data/32/base/EQV.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/32/base/EQVo.sem
+++ b/semmc-ppc/data/32/base/EQVo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/MFOCRF.sem
+++ b/semmc-ppc/data/32/base/MFOCRF.sem
@@ -6,18 +6,34 @@
   ('CR rT FXM 'IP))
  (defs
   ((rT
-   (bvand
-    ((_ call "df.mask_32")
-     (bvmul
-      ((_ zero_extend 24)
-       FXM)
-      #x00000004)
-     (bvadd
+   (bvor
+    (bvand
+     ((_ call "df.mask_32")
       (bvmul
        ((_ zero_extend 24)
         FXM)
        #x00000004)
-      #x00000003))
-    'CR))
+      (bvadd
+       (bvmul
+        ((_ zero_extend 24)
+         FXM)
+        #x00000004)
+       #x00000003))
+     'CR)
+    (bvand
+     (bvnot
+      ((_ call "df.mask_32")
+       (bvmul
+        ((_ zero_extend 24)
+         FXM)
+        #x00000004)
+       (bvadd
+        (bvmul
+         ((_ zero_extend 24)
+          FXM)
+         #x00000004)
+        #x00000003)))
+     ((_ call "uf.undefined")
+      #x00000020))))
    ('IP
     (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/MULHW.sem
+++ b/semmc-ppc/data/32/base/MULHW.sem
@@ -6,7 +6,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 63 32)

--- a/semmc-ppc/data/32/base/MULHWU.sem
+++ b/semmc-ppc/data/32/base/MULHWU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 63 32)

--- a/semmc-ppc/data/32/base/MULHWUo.sem
+++ b/semmc-ppc/data/32/base/MULHWUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/MULHWo.sem
+++ b/semmc-ppc/data/32/base/MULHWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/MULLI.sem
+++ b/semmc-ppc/data/32/base/MULLI.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  (si rA 'IP))
+  (rA si 'IP))
  (defs
   ((rT
    (bvmul

--- a/semmc-ppc/data/32/base/MULLW.sem
+++ b/semmc-ppc/data/32/base/MULLW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 31 0)

--- a/semmc-ppc/data/32/base/MULLWo.sem
+++ b/semmc-ppc/data/32/base/MULLWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/NAND.sem
+++ b/semmc-ppc/data/32/base/NAND.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/32/base/NANDo.sem
+++ b/semmc-ppc/data/32/base/NANDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/NOR.sem
+++ b/semmc-ppc/data/32/base/NOR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/32/base/NORo.sem
+++ b/semmc-ppc/data/32/base/NORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/OR.sem
+++ b/semmc-ppc/data/32/base/OR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvor rS rB))

--- a/semmc-ppc/data/32/base/ORC.sem
+++ b/semmc-ppc/data/32/base/ORC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvor

--- a/semmc-ppc/data/32/base/ORCo.sem
+++ b/semmc-ppc/data/32/base/ORCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/ORo.sem
+++ b/semmc-ppc/data/32/base/ORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SLW.sem
+++ b/semmc-ppc/data/32/base/SLW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvshl

--- a/semmc-ppc/data/32/base/SLWo.sem
+++ b/semmc-ppc/data/32/base/SLWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SRAW.sem
+++ b/semmc-ppc/data/32/base/SRAW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER rB rS 'IP))
+  ('XER rS rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/SRAWo.sem
+++ b/semmc-ppc/data/32/base/SRAWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rS 'IP))
+  ('XER 'CR 'XER rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SRW.sem
+++ b/semmc-ppc/data/32/base/SRW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvlshr

--- a/semmc-ppc/data/32/base/SRWo.sem
+++ b/semmc-ppc/data/32/base/SRWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SUBF.sem
+++ b/semmc-ppc/data/32/base/SUBF.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvsub rB rA))

--- a/semmc-ppc/data/32/base/SUBFC.sem
+++ b/semmc-ppc/data/32/base/SUBFC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/SUBFCo.sem
+++ b/semmc-ppc/data/32/base/SUBFCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SUBFE.sem
+++ b/semmc-ppc/data/32/base/SUBFE.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/SUBFEo.sem
+++ b/semmc-ppc/data/32/base/SUBFEo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/SUBFIC.sem
+++ b/semmc-ppc/data/32/base/SUBFIC.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER si rA 'IP))
+  ('XER rA si 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/32/base/SUBFo.sem
+++ b/semmc-ppc/data/32/base/SUBFo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/base/VMHADDSHS.sem
+++ b/semmc-ppc/data/32/base/VMHADDSHS.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-High-Add Signed Halfword Saturate (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMHADDSHS"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMHADDSHS"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMHRADDSHS.sem
+++ b/semmc-ppc/data/32/base/VMHRADDSHS.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-High-Round-Add Signed Halfword Saturate (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMHRADDSHS"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMHRADDSHS"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMLADDUHM.sem
+++ b/semmc-ppc/data/32/base/VMLADDUHM.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Low-Add Unsigned Halfword Modulo (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMLADDUHM"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMLADDUHM"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMMBM.sem
+++ b/semmc-ppc/data/32/base/VMSUMMBM.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Mixed Byte Modulo (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMMBM"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMMBM"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMSHM.sem
+++ b/semmc-ppc/data/32/base/VMSUMSHM.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Signed Halfword Modulo (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMSHM"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMSHM"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMSHS.sem
+++ b/semmc-ppc/data/32/base/VMSUMSHS.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Signed Halfword Saturate (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMSHS"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMSHS"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMUBM.sem
+++ b/semmc-ppc/data/32/base/VMSUMUBM.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Unsigned Byte Modulo (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMUBM"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMUBM"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMUHM.sem
+++ b/semmc-ppc/data/32/base/VMSUMUHM.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Unsigned Halfword Modulo (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMUHM"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMUHM"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/VMSUMUHS.sem
+++ b/semmc-ppc/data/32/base/VMSUMUHS.sem
@@ -1,0 +1,27 @@
+;; Vector Multiply-Sum Unsigned Halfword Saturate (VA-form)
+((operands
+ ((vrT . 'Vrrc)
+  (vrA . 'Vrrc)
+  (vrB . 'Vrrc)
+  (vrC . 'Vrrc)))
+ (in
+  ('VSCR vrC vrB vrA 'IP))
+ (defs
+  (('VSCR
+   ((_ extract 31 0)
+    ((_ call "uf.ppc.vec3")
+     "VMSUMUHS"
+     vrA
+     vrB
+     vrC
+     'VSCR)))
+   (vrT
+    ((_ extract 159 32)
+     ((_ call "uf.ppc.vec3")
+      "VMSUMUHS"
+      vrA
+      vrB
+      vrC
+      'VSCR)))
+   ('IP
+    (bvadd 'IP #x00000004)))))

--- a/semmc-ppc/data/32/base/XOR.sem
+++ b/semmc-ppc/data/32/base/XOR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvxor rS rB))

--- a/semmc-ppc/data/32/base/XORo.sem
+++ b/semmc-ppc/data/32/base/XORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/32/manual/LI.sem
+++ b/semmc-ppc/data/32/manual/LI.sem
@@ -2,7 +2,7 @@
  ((rA . 'Gprc)
   (imm . 'S16imm)))
  (in
-  (imm rA 'IP))
+  (imm 'IP))
  (defs
   ((rA
    ((_ sign_extend 16)

--- a/semmc-ppc/data/64/base/ADD4.sem
+++ b/semmc-ppc/data/64/base/ADD4.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvadd rA rB))

--- a/semmc-ppc/data/64/base/ADD4o.sem
+++ b/semmc-ppc/data/64/base/ADD4o.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/ADDC.sem
+++ b/semmc-ppc/data/64/base/ADDC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/ADDCo.sem
+++ b/semmc-ppc/data/64/base/ADDCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/ADDE.sem
+++ b/semmc-ppc/data/64/base/ADDE.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/ADDEo.sem
+++ b/semmc-ppc/data/64/base/ADDEo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/ADDIC.sem
+++ b/semmc-ppc/data/64/base/ADDIC.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER si rA 'IP))
+  ('XER rA si 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/ADDICo.sem
+++ b/semmc-ppc/data/64/base/ADDICo.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER si rA 'IP))
+  ('XER 'CR 'XER rA si 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/AND.sem
+++ b/semmc-ppc/data/64/base/AND.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvand rS rB))

--- a/semmc-ppc/data/64/base/ANDC.sem
+++ b/semmc-ppc/data/64/base/ANDC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvand

--- a/semmc-ppc/data/64/base/ANDCo.sem
+++ b/semmc-ppc/data/64/base/ANDCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/ANDo.sem
+++ b/semmc-ppc/data/64/base/ANDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/BPERMD.sem
+++ b/semmc-ppc/data/64/base/BPERMD.sem
@@ -155,5 +155,5 @@
    (rB . 'Gprc)
    (rS . 'Gprc)))
   (in
-   (rB rS 'IP))
+   (rS rB 'IP))
   (var1)))

--- a/semmc-ppc/data/64/base/CMPB.sem
+++ b/semmc-ppc/data/64/base/CMPB.sem
@@ -81,5 +81,5 @@
    (rB . 'Gprc)
    (rS . 'Gprc)))
   (in
-   (rB rS 'IP))
+   (rS rB 'IP))
   (var1)))

--- a/semmc-ppc/data/64/base/DIVD.sem
+++ b/semmc-ppc/data/64/base/DIVD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvsdiv rA rB))

--- a/semmc-ppc/data/64/base/DIVDU.sem
+++ b/semmc-ppc/data/64/base/DIVDU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvudiv rA rB))

--- a/semmc-ppc/data/64/base/DIVDUo.sem
+++ b/semmc-ppc/data/64/base/DIVDUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/DIVDo.sem
+++ b/semmc-ppc/data/64/base/DIVDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/DIVW.sem
+++ b/semmc-ppc/data/64/base/DIVW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvsdiv

--- a/semmc-ppc/data/64/base/DIVWU.sem
+++ b/semmc-ppc/data/64/base/DIVWU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvudiv

--- a/semmc-ppc/data/64/base/DIVWUo.sem
+++ b/semmc-ppc/data/64/base/DIVWUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/DIVWo.sem
+++ b/semmc-ppc/data/64/base/DIVWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/EQV.sem
+++ b/semmc-ppc/data/64/base/EQV.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/64/base/EQVo.sem
+++ b/semmc-ppc/data/64/base/EQVo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MFOCRF.sem
+++ b/semmc-ppc/data/64/base/MFOCRF.sem
@@ -6,19 +6,35 @@
   ('CR rT FXM 'IP))
  (defs
   ((rT
-   ((_ zero_extend 32)
+   (bvor
     (bvand
-     ((_ call "df.mask_32")
+     ((_ call "df.mask_64")
       (bvmul
-       ((_ zero_extend 24)
+       ((_ zero_extend 56)
         FXM)
-       #x00000004)
+       #x0000000000000004)
       (bvadd
        (bvmul
-        ((_ zero_extend 24)
+        ((_ zero_extend 56)
          FXM)
-        #x00000004)
-       #x00000003))
-     'CR)))
+        #x0000000000000004)
+       #x0000000000000003))
+     ((_ zero_extend 32)
+      'CR))
+    (bvand
+     (bvnot
+      ((_ call "df.mask_64")
+       (bvmul
+        ((_ zero_extend 56)
+         FXM)
+        #x0000000000000004)
+       (bvadd
+        (bvmul
+         ((_ zero_extend 56)
+          FXM)
+         #x0000000000000004)
+        #x0000000000000003)))
+     ((_ call "uf.undefined")
+      #x00000040))))
    ('IP
     (bvadd 'IP #x0000000000000004)))))

--- a/semmc-ppc/data/64/base/MULHD.sem
+++ b/semmc-ppc/data/64/base/MULHD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 127 64)

--- a/semmc-ppc/data/64/base/MULHDU.sem
+++ b/semmc-ppc/data/64/base/MULHDU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 127 64)

--- a/semmc-ppc/data/64/base/MULHDUo.sem
+++ b/semmc-ppc/data/64/base/MULHDUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MULHDo.sem
+++ b/semmc-ppc/data/64/base/MULHDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MULHW.sem
+++ b/semmc-ppc/data/64/base/MULHW.sem
@@ -6,7 +6,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ zero_extend 32)

--- a/semmc-ppc/data/64/base/MULHWU.sem
+++ b/semmc-ppc/data/64/base/MULHWU.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ zero_extend 32)

--- a/semmc-ppc/data/64/base/MULHWUo.sem
+++ b/semmc-ppc/data/64/base/MULHWUo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MULHWo.sem
+++ b/semmc-ppc/data/64/base/MULHWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MULLD.sem
+++ b/semmc-ppc/data/64/base/MULLD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ extract 63 0)

--- a/semmc-ppc/data/64/base/MULLDo.sem
+++ b/semmc-ppc/data/64/base/MULLDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/MULLI.sem
+++ b/semmc-ppc/data/64/base/MULLI.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  (si rA 'IP))
+  (rA si 'IP))
  (defs
   ((rT
    (bvmul

--- a/semmc-ppc/data/64/base/MULLW.sem
+++ b/semmc-ppc/data/64/base/MULLW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    ((_ zero_extend 32)

--- a/semmc-ppc/data/64/base/MULLWo.sem
+++ b/semmc-ppc/data/64/base/MULLWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/NAND.sem
+++ b/semmc-ppc/data/64/base/NAND.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/64/base/NANDo.sem
+++ b/semmc-ppc/data/64/base/NANDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/NOR.sem
+++ b/semmc-ppc/data/64/base/NOR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvnot

--- a/semmc-ppc/data/64/base/NORo.sem
+++ b/semmc-ppc/data/64/base/NORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/OR.sem
+++ b/semmc-ppc/data/64/base/OR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvor rS rB))

--- a/semmc-ppc/data/64/base/ORC.sem
+++ b/semmc-ppc/data/64/base/ORC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvor

--- a/semmc-ppc/data/64/base/ORCo.sem
+++ b/semmc-ppc/data/64/base/ORCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/ORo.sem
+++ b/semmc-ppc/data/64/base/ORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SLD.sem
+++ b/semmc-ppc/data/64/base/SLD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvshl

--- a/semmc-ppc/data/64/base/SLDo.sem
+++ b/semmc-ppc/data/64/base/SLDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SLW.sem
+++ b/semmc-ppc/data/64/base/SLW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    ((_ zero_extend 32)

--- a/semmc-ppc/data/64/base/SLWo.sem
+++ b/semmc-ppc/data/64/base/SLWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SRAD.sem
+++ b/semmc-ppc/data/64/base/SRAD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER rB rS 'IP))
+  ('XER rS rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/SRADo.sem
+++ b/semmc-ppc/data/64/base/SRADo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rS 'IP))
+  ('XER 'CR 'XER rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SRAW.sem
+++ b/semmc-ppc/data/64/base/SRAW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER rB rS 'IP))
+  ('XER rS rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/SRAWo.sem
+++ b/semmc-ppc/data/64/base/SRAWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rS 'IP))
+  ('XER 'CR 'XER rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SRD.sem
+++ b/semmc-ppc/data/64/base/SRD.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvlshr

--- a/semmc-ppc/data/64/base/SRDo.sem
+++ b/semmc-ppc/data/64/base/SRDo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SRW.sem
+++ b/semmc-ppc/data/64/base/SRW.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    ((_ zero_extend 32)

--- a/semmc-ppc/data/64/base/SRWo.sem
+++ b/semmc-ppc/data/64/base/SRWo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SUBF.sem
+++ b/semmc-ppc/data/64/base/SUBF.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  (rB rA 'IP))
+  (rA rB 'IP))
  (defs
   ((rT
    (bvsub rB rA))

--- a/semmc-ppc/data/64/base/SUBFC.sem
+++ b/semmc-ppc/data/64/base/SUBFC.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/SUBFCo.sem
+++ b/semmc-ppc/data/64/base/SUBFCo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SUBFE.sem
+++ b/semmc-ppc/data/64/base/SUBFE.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER rB rA 'IP))
+  ('XER rA rB 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/SUBFEo.sem
+++ b/semmc-ppc/data/64/base/SUBFEo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR 'XER rB rA 'IP))
+  ('XER 'CR 'XER rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/SUBFIC.sem
+++ b/semmc-ppc/data/64/base/SUBFIC.sem
@@ -4,7 +4,7 @@
   (si . 'S16imm)
   (rA . 'Gprc)))
  (in
-  ('XER si rA 'IP))
+  ('XER rA si 'IP))
  (defs
   (('XER
    (concat

--- a/semmc-ppc/data/64/base/SUBFo.sem
+++ b/semmc-ppc/data/64/base/SUBFo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rA . 'Gprc)))
  (in
-  ('XER 'CR rB rA 'IP))
+  ('XER 'CR rA rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/base/XOR.sem
+++ b/semmc-ppc/data/64/base/XOR.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  (rB rS 'IP))
+  (rS rB 'IP))
  (defs
   ((rA
    (bvxor rS rB))

--- a/semmc-ppc/data/64/base/XORo.sem
+++ b/semmc-ppc/data/64/base/XORo.sem
@@ -4,7 +4,7 @@
   (rB . 'Gprc)
   (rS . 'Gprc)))
  (in
-  ('XER 'CR rB rS 'IP))
+  ('XER 'CR rS rB 'IP))
  (defs
   (('CR
    ((_ call "df.cmpImm")

--- a/semmc-ppc/data/64/manual/LI.sem
+++ b/semmc-ppc/data/64/manual/LI.sem
@@ -2,7 +2,7 @@
  ((rA . 'Gprc)
   (imm . 'S16imm)))
  (in
-  (imm rA 'IP))
+  (imm 'IP))
  (defs
   ((rA
    ((_ sign_extend 48)

--- a/semmc-ppc/src/SemMC/Architecture/PPC/Base.hs
+++ b/semmc-ppc/src/SemMC/Architecture/PPC/Base.hs
@@ -107,7 +107,6 @@ manual bitSize = runSem $ do
   defineOpcodeWithIP "LI" $ do
     rA <- param "rA" gprc naturalBV
     imm <- param "imm" s16imm (EBV 16)
-    input rA
     input imm
     defLoc rA (sext (Loc imm))
   defineOpcodeWithIP "LIS" $ do
@@ -144,3 +143,4 @@ intrinsic with its constant fixed to zero.  That would let us learn most of the
 dotted variants.
 
 -}
+

--- a/semmc-ppc/src/SemMC/Architecture/PPC/Base/Special.hs
+++ b/semmc-ppc/src/SemMC/Architecture/PPC/Base/Special.hs
@@ -108,7 +108,6 @@ baseSpecial = do
     let res = newCR
     defLoc cr res
 
-{- TODO: Generating errors when running scripts/genbase.sh, needs to be resolved
   defineOpcodeWithIP "MFOCRF" $ do
     comment "Move From One Condition Register Field (XFX-form)"
     rT <- param "rT" gprc naturalBV
@@ -119,15 +118,14 @@ baseSpecial = do
 
     -- let check = bvpopcnt (zext' 32 (Loc crbit))
     -- let fieldIndex = bvclz (zext' 32 (Loc crbit))
-    let fieldIndex = zext' 32 (Loc crbit)
-    let fieldBitStart = bvmul fieldIndex (LitBV 32 0x4)
-    let fieldBitEnd = bvadd fieldBitStart (LitBV 32 0x3)
-    let fieldMask = mask 32 fieldBitStart fieldBitEnd
-    let rTMask = bvnot $ mask 64 fieldBitStart fieldBitEnd
+    let fieldIndex = zext (Loc crbit)
+    let fieldBitStart = bvmul fieldIndex (naturalLitBV 0x4)
+    let fieldBitEnd = bvadd fieldBitStart (naturalLitBV 0x3)
+    let fieldMask = mask (bitSizeValue ?bitSize) fieldBitStart fieldBitEnd
+    let rTMask = bvnot $ mask (bitSizeValue ?bitSize) fieldBitStart fieldBitEnd
     let newRT = bvor
-          (zext $ bvand fieldMask (Loc cr))
-          (bvand rTMask (undefinedBV 64))
+          (bvand fieldMask (zext (Loc cr)))
+          (bvand rTMask (undefinedBV (bitSizeValue ?bitSize)))
     -- let res = ite (bveq check (LitBV 32 0x1)) newRT (undefinedBV 64)
     let res = newRT
     defLoc rT res
--}

--- a/semmc-ppc/src/SemMC/Architecture/PPC/Base/Special.hs
+++ b/semmc-ppc/src/SemMC/Architecture/PPC/Base/Special.hs
@@ -108,6 +108,7 @@ baseSpecial = do
     let res = newCR
     defLoc cr res
 
+{- TODO: Generating errors when running scripts/genbase.sh, needs to be resolved
   defineOpcodeWithIP "MFOCRF" $ do
     comment "Move From One Condition Register Field (XFX-form)"
     rT <- param "rT" gprc naturalBV
@@ -129,3 +130,4 @@ baseSpecial = do
     -- let res = ite (bveq check (LitBV 32 0x1)) newRT (undefinedBV 64)
     let res = newRT
     defLoc rT res
+-}

--- a/semmc-ppc/src/SemMC/Architecture/PPC64/Opcodes/Internal.hs
+++ b/semmc-ppc/src/SemMC/Architecture/PPC64/Opcodes/Internal.hs
@@ -19,3 +19,4 @@ allOpcodeInfo = $(DT.captureInfo (const True) ''PPC.Opcode)
 -- | All opcodes known for the architecture
 allOpcodes :: [Some (PPC.Opcode PPC.Operand)]
 allOpcodes = map (mapSome DT.capturedOpcode) allOpcodeInfo
+


### PR DESCRIPTION
The core file changed was `semmc-ppc/src/SemMC/Architecture/PPC/Base.hs`, with the intention of fixing the semantics of `LI` so that `rA` is no longer listed as an input. I then re-ran the `genbase.sh` script to generate the semantics files; many files were changed, possibly from an earlier commit.

Before merging, we need to reinstate the commented-out code in `semmc-ppc/src/SemMC/Architecture/PPC/Base/Special.hs`, which was throwing an error during `genbase.sh` that prevented `LI` from being generated. Contributions from @travitch or advice on what to do there are welcome.