### PR TITLE
Formula store and load tests

### DIFF
--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -163,10 +163,13 @@ test-suite semmc-semstore-tests
                , bytestring
                , containers
                , crucible
+               , dismantle-tablegen
+               , hashable
                , hedgehog
                , parameterized-utils
                , semmc
                , tasty
                , tasty-hunit
                , tasty-hedgehog
+               , text
                , what4

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -154,6 +154,7 @@ test-suite semmc-semstore-tests
   ghc-options: -Wall
   main-is: SemStore.hs
   other-modules: LocationsTests
+               , ParameterTests
                , TestArch
                , TestArchPropGen
   hs-source-dirs: tests/semstore

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -155,6 +155,7 @@ test-suite semmc-semstore-tests
   main-is: SemStore.hs
   other-modules: LocationsTests
                , ParameterTests
+               , ParamFormulaTests
                , TestArch
                , TestArchPropGen
   hs-source-dirs: tests/semstore

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -153,7 +153,8 @@ test-suite semmc-semstore-tests
   type: exitcode-stdio-1.0
   ghc-options: -Wall
   main-is: SemStore.hs
-  other-modules: LocationsTests
+  other-modules: HedgehogUtil
+               , LocationsTests
                , ParameterTests
                , ParamFormulaTests
                , TestArch
@@ -165,6 +166,7 @@ test-suite semmc-semstore-tests
                , containers
                , crucible
                , dismantle-tablegen
+               , exceptions
                , hashable
                , hedgehog
                , parameterized-utils
@@ -173,4 +175,5 @@ test-suite semmc-semstore-tests
                , tasty-hunit
                , tasty-hedgehog
                , text
+               , transformers
                , what4

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -144,3 +144,27 @@ test-suite semmc-tests
                  , tasty-hunit
                  , async
                  , directory
+
+
+test-suite semmc-semstore-tests
+  -- Tests for verifying semantics can be stored and subsequently read
+  -- back in as a round-trip (validating the parser and the printer).
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall
+  main-is: SemStore.hs
+  other-modules: LocationsTests
+               , TestArch
+               , TestArchPropGen
+  hs-source-dirs: tests/semstore
+  build-depends: base
+               , bytestring
+               , containers
+               , crucible
+               , hedgehog
+               , parameterized-utils
+               , semmc
+               , tasty
+               , tasty-hunit
+               , tasty-hedgehog
+               , what4

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -158,6 +158,7 @@ test-suite semmc-semstore-tests
                , ParamFormulaTests
                , TestArch
                , TestArchPropGen
+               , TestUtils
   hs-source-dirs: tests/semstore
   build-depends: base
                , bytestring

--- a/semmc/src/SemMC/Formula/Load.hs
+++ b/semmc/src/SemMC/Formula/Load.hs
@@ -228,6 +228,7 @@ loadLibraryFromFiles proxy sym dir = do
 
 listFunctionFiles :: FilePath -> IO [FilePath]
 listFunctionFiles dir =
+  (fmap $ S.combine dir) <$>
   filter isFunctionFile <$>
     E.catch (S.listDirectory dir) (\(_::E.SomeException) -> return [])
   where isFunctionFile f = snd (S.splitExtension f) == ".fun"

--- a/semmc/src/SemMC/TH.hs
+++ b/semmc/src/SemMC/TH.hs
@@ -104,8 +104,8 @@ findFunctionFiles dir = do
   fs <- listFunctionFiles dir
   forM fs $ \f -> do
     let funName = dropExtension f
-    bs <- BS.readFile (dir </> f)
-    return (dir </> f, funName, bs)
+    bs <- BS.readFile f
+    return (f, funName, bs)
 
 toFunctionPair :: (FilePath, String, BS.ByteString) -> ExpQ
 toFunctionPair (_, name, bs) = tupE [ [| $(litE (StringL name)) |], embedByteString bs ]

--- a/semmc/tests/semstore/HedgehogUtil.hs
+++ b/semmc/tests/semstore/HedgehogUtil.hs
@@ -1,0 +1,89 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Utilities related to Hedgehog testing that are not supplied by
+-- Hedgehog itself.
+--
+-- Primarily at this point:
+--  * a MonadMask instance for PropertyT.
+
+module HedgehogUtil where
+
+import qualified Control.Monad.Catch as E
+import           Control.Monad.Trans.Class ( lift )
+import           Hedgehog.Internal.Gen
+import           Hedgehog.Internal.Property
+import           Hedgehog.Internal.Tree
+
+
+instance E.MonadMask m => E.MonadMask (TreeT m) where
+  mask a = TreeT $ E.mask $ \u -> runTreeT (a $ mapTreeT u)
+
+  uninterruptibleMask a =
+    TreeT $ E.uninterruptibleMask $ \u -> runTreeT (a $ mapTreeT u)
+
+  generalBracket acquire release use =
+    lift $ E.generalBracket
+              (treeAcquire acquire)
+              (treeRelease release)
+              (treeUse use)
+
+treeAcquire :: TreeT m a -> m (NodeT m a)
+treeAcquire acquire = runTreeT acquire
+
+treeRelease :: Monad m =>
+               (a -> E.ExitCase b -> TreeT m c)
+            -> NodeT m a
+            -> E.ExitCase b
+            -> m c
+treeRelease release resource exitCase =
+  nodeValue <$> runTreeT (release (nodeValue resource) exitCase)
+
+treeUse :: Monad m => (a -> TreeT m b) -> NodeT m a -> m b
+treeUse use resource =
+  nodeValue <$> runTreeT (use (nodeValue resource))
+
+instance E.MonadMask m => E.MonadMask (GenT m) where
+  mask a = GenT $ \sz -> \seed -> E.mask $ \u -> unGenT (a $ q u) sz seed
+    where q u o = GenT $ \sz' -> \seed' -> u $ unGenT o sz' seed'
+
+  uninterruptibleMask a =
+    GenT $ \sz -> \seed ->
+                    E.uninterruptibleMask $ \u ->
+                                              unGenT (a $ q u) sz seed
+    where q u o = GenT $ \sz' -> \seed' -> u $ unGenT o sz' seed'
+
+  generalBracket acquire release use = GenT $ \sz -> \seed ->
+    E.generalBracket
+    (unGenT acquire sz seed)
+    (\resource exitCase -> unGenT (release resource exitCase) sz seed)
+    (\resource -> unGenT (use resource) sz seed)
+
+
+instance E.MonadMask m => E.MonadMask (TestT m) where
+  mask a = TestT $ E.mask $ \u -> unTest (a $ q u)
+    where q u = TestT . u . unTest
+
+  uninterruptibleMask a =
+    TestT $ E.uninterruptibleMask $ \u -> unTest (a $ q u)
+    where q u = TestT . u . unTest
+
+  generalBracket acquire release use = TestT $
+    E.generalBracket
+    (unTest acquire)
+    (\resource exitCase -> unTest (release resource exitCase))
+    (\resource -> unTest (use resource))
+
+
+instance E.MonadMask m => E.MonadMask (PropertyT m) where
+  mask a = PropertyT $ E.mask $ \u -> unPropertyT (a $ q u)
+    where q u = PropertyT . u . unPropertyT
+
+  uninterruptibleMask a =
+    PropertyT $ E.uninterruptibleMask $ \u -> unPropertyT (a $ q u)
+    where q u = PropertyT . u . unPropertyT
+
+  generalBracket acquire release use = PropertyT $
+    E.generalBracket
+    (unPropertyT acquire)
+    (\resource exitCase -> unPropertyT (release resource exitCase))
+    (\resource -> unPropertyT (use resource))

--- a/semmc/tests/semstore/LocationsTests.hs
+++ b/semmc/tests/semstore/LocationsTests.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module LocationsTests where
+
+import           Data.Parameterized.Classes
+import qualified SemMC.Architecture.Location as L
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import           TestArch
+import           TestArchPropGen
+import           What4.BaseTypes
+import           Hedgehog
+
+import           Prelude
+
+
+locationTests :: [TestTree]
+locationTests = [
+  testGroup "Location" $
+
+    [ testGroup "Nat" $
+      [ testProperty "location value distribution" $ -- test generator validity
+        property $ do l <- forAll genNatLocation
+                      let locNat = case l of { TestNatLoc n -> n }
+                      -- classify "natloc 0" (locNat == 0)
+                      -- classify "natloc single" (locNat == 1)
+                      -- classify "natloc multiple" (locNat >= 2)
+                      cover 1 "natloc 0" $ locNat == 0
+                      cover 1 "natloc single" $ locNat == 1
+                      success
+      , testProperty "location type" $
+        property $ do l <- forAll genNatLocation
+                      case testEquality (L.locationType l) BaseNatRepr of
+                          Just Refl -> success
+                          Nothing -> assert False
+      , testProperty "is mem location" $
+        property $ do l <- forAll genNatLocation
+                      assert $ not $ L.isMemoryLocation l
+      -- TBD: needs other tests
+      ]
+
+    , testGroup "Integer" $
+      [ testProperty "location value distribution" $ -- test generator validity
+        property $ do l <- forAll genIntLocation
+                      let locVal = case l of { TestIntLoc n -> n }
+                      cover 1 "intloc 0" $ locVal == 0
+                      cover 1 "intloc single" $ locVal == 1
+                      cover 10 "intloc negative" $ locVal < 0
+                      success
+      , testProperty "location type" $
+        property $ do l <- forAll $ genIntLocation
+                      case testEquality (L.locationType l) BaseIntegerRepr of
+                        Just Refl -> success
+                        Nothing -> assert False
+      , testProperty "is mem location" $
+        property $ do l <- forAll genNatLocation
+                      assert $ not $ L.isMemoryLocation l
+      -- TBD: needs other tests
+      ]
+    ]
+
+  ]

--- a/semmc/tests/semstore/LocationsTests.hs
+++ b/semmc/tests/semstore/LocationsTests.hs
@@ -64,11 +64,15 @@ locationTests = [
     , testGroup "Reg32" $
       [ testProperty "location value distribution" $ -- test generator validity
         property $ do l <- forAll genRegLocation
-                      let locVal = case l of { TestRegLoc n -> n }
+                      let locVal = case l of
+                                     TestRegLoc n -> n
+                                     TestBarLoc -> 99
                       cover 10 "reg32loc 0" $ locVal == 0
                       cover 10 "reg32loc 1" $ locVal == 1
                       cover 10 "reg32loc 2" $ locVal == 2
                       cover 10 "reg32loc 3" $ locVal == 3
+                      -- a genRegLocation should never return a Bar location
+                      locVal /== 99
                       success
       , testProperty "location type" $
         property $ do l <- forAll $ genRegLocation

--- a/semmc/tests/semstore/LocationsTests.hs
+++ b/semmc/tests/semstore/LocationsTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -59,6 +60,28 @@ locationTests = [
                       assert $ not $ L.isMemoryLocation l
       -- TBD: needs other tests
       ]
+
+    , testGroup "Reg32" $
+      [ testProperty "location value distribution" $ -- test generator validity
+        property $ do l <- forAll genRegLocation
+                      let locVal = case l of { TestRegLoc n -> n }
+                      cover 10 "reg32loc 0" $ locVal == 0
+                      cover 10 "reg32loc 1" $ locVal == 1
+                      cover 10 "reg32loc 2" $ locVal == 2
+                      cover 10 "reg32loc 3" $ locVal == 3
+                      success
+      , testProperty "location type" $
+        property $ do l <- forAll $ genRegLocation
+                      let aBV32 = BaseBVRepr knownNat :: BaseTypeRepr (BaseBVType 32)
+                      case testEquality (L.locationType l) aBV32 of
+                        Just Refl -> success
+                        Nothing -> assert False
+      , testProperty "is mem location" $
+        property $ do l <- forAll genNatLocation
+                      assert $ not $ L.isMemoryLocation l
+      -- TBD: needs other tests
+      ]
+
     ]
 
   ]

--- a/semmc/tests/semstore/LocationsTests.hs
+++ b/semmc/tests/semstore/LocationsTests.hs
@@ -61,21 +61,21 @@ locationTests = [
       -- TBD: needs other tests
       ]
 
-    , testGroup "Reg32" $
+    , testGroup "Box (BV32)" $
       [ testProperty "location value distribution" $ -- test generator validity
-        property $ do l <- forAll genRegLocation
+        property $ do l <- forAll genBoxLocation
                       let locVal = case l of
                                      TestBoxLoc n -> n
                                      TestBarLoc -> 99
-                      cover 10 "reg32loc 0" $ locVal == 0
-                      cover 10 "reg32loc 1" $ locVal == 1
-                      cover 10 "reg32loc 2" $ locVal == 2
-                      cover 10 "reg32loc 3" $ locVal == 3
-                      -- a genRegLocation should never return a Bar location
+                      cover 10 "box32loc 0" $ locVal == 0
+                      cover 10 "box32loc 1" $ locVal == 1
+                      cover 10 "box32loc 2" $ locVal == 2
+                      cover 10 "box32loc 3" $ locVal == 3
+                      -- a genBoxLocation should never return a Bar location
                       locVal /== 99
                       success
       , testProperty "location type" $
-        property $ do l <- forAll $ genRegLocation
+        property $ do l <- forAll $ genBoxLocation
                       let aBV32 = BaseBVRepr knownNat :: BaseTypeRepr (BaseBVType 32)
                       case testEquality (L.locationType l) aBV32 of
                         Just Refl -> success

--- a/semmc/tests/semstore/LocationsTests.hs
+++ b/semmc/tests/semstore/LocationsTests.hs
@@ -65,7 +65,7 @@ locationTests = [
       [ testProperty "location value distribution" $ -- test generator validity
         property $ do l <- forAll genRegLocation
                       let locVal = case l of
-                                     TestRegLoc n -> n
+                                     TestBoxLoc n -> n
                                      TestBarLoc -> 99
                       cover 10 "reg32loc 0" $ locVal == 0
                       cover 10 "reg32loc 1" $ locVal == 1

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -79,7 +79,7 @@ parameterizedFormulaTests = [
                     debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
                     let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
                     debugPrint $ "printedFormula: " <> show printedFormula
-                    let fenv = undefined
+                    let fenv = error "Formula Environment TBD"
                     lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
                     reForm <- liftIO $
                               Log.withLogCfg lcfg $
@@ -98,7 +98,7 @@ parameterizedFormulaTests = [
                     debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
                     let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
                     debugPrint $ "printedFormula: " <> show printedFormula
-                    let fenv = undefined
+                    let fenv = error "Formula Environment TBD"
                     lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
                     reForm <- liftIO $
                               Log.withLogCfg lcfg $
@@ -117,7 +117,7 @@ parameterizedFormulaTests = [
                     debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
                     let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
                     debugPrint $ "printedFormula: " <> show printedFormula
-                    let fenv = undefined
+                    let fenv = error "Formula Environment TBD"
                     lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
                     reForm <- liftIO $
                               Log.withLogCfg lcfg $
@@ -143,7 +143,7 @@ parameterizedFormulaTests = [
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
           debugPrint $ "printedFormula: " <> show printedFormula
           -- convert the printed text string back into a formula
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
@@ -170,7 +170,7 @@ parameterizedFormulaTests = [
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
           debugPrint $ "printedFormula: " <> show printedFormula
           -- convert the printed text string back into a formula
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
@@ -197,7 +197,7 @@ parameterizedFormulaTests = [
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
           debugPrint $ "printedFormula: " <> show printedFormula
           -- convert the printed text string back into a formula
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
@@ -219,7 +219,7 @@ parameterizedFormulaTests = [
 
           -- first round trip:
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
                     FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
@@ -250,7 +250,7 @@ parameterizedFormulaTests = [
 
           -- first round trip:
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
                     FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
@@ -280,7 +280,7 @@ parameterizedFormulaTests = [
 
           -- first round trip:
           let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
-          let fenv = undefined
+          let fenv = error "Formula Environment TBD"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
                     FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -8,15 +8,28 @@
 
 module ParamFormulaTests where
 
+import           Control.Monad.IO.Class ( liftIO )
+import           Data.Either
+import qualified Data.Foldable as F
 import           Data.Parameterized.Classes
-import           Data.Parameterized.Some
 import qualified Data.Parameterized.List as SL
+import qualified Data.Parameterized.Map as MapF
+import           Data.Parameterized.Nonce
+import qualified SemMC.Log as Log
+import           Data.Parameterized.Some
+import qualified Data.Set as Set
+import           Hedgehog
+import           Hedgehog.Internal.Property ( forAllT )
+import           Lang.Crucible.Backend.Simple ( newSimpleBackend )
+import qualified SemMC.BoundVar as BV
+import qualified SemMC.Formula.Formula as SF
+import qualified SemMC.Formula.Parser as FI
+import qualified SemMC.Formula.Printer as FO
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
-import qualified SemMC.Formula.Formula as F
+import           TestArch
 import           TestArchPropGen
 import           What4.BaseTypes
-import           Hedgehog
 
 import           Prelude
 
@@ -26,24 +39,61 @@ parameterizedFormulaTests = [
   testGroup "Parameterized Formulas" $
 
     [ testProperty "parameter type" $
-      property $ do p <- forAll (genParameterizedFormula @'["NatArg:Foo"] TestSymbolicBackend)
-                    assert (all isValidParamType (F.pfUses p))
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    assert (all isValidParamType (SF.pfUses p))
     , testProperty "operand type" $
-      property $ do p <- forAll (genParameterizedFormula @'["NatArg:Foo"] TestSymbolicBackend)
-                    assert $ isNatArgFoo ((F.pfOperandVars p) SL.!! SL.index0)
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    assert $ isNatArgFoo ((SF.pfOperandVars p) SL.!! SL.index0)
+    , testProperty "literal vars" $
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    success -- TBD: something (manything?) to test literal vars here
       -- TBD: needs other tests
+    , testProperty "defs keys in uses" $
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    assert (all (flip Set.member (SF.pfUses p)) (MapF.keys $ SF.pfDefs p))
+
+    , testProperty "serialized formula" $
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    liftIO $ putStrLn $ "parameterizedFormula: " <> show p
+                    liftIO $ putStrLn $ "# literalVars: " <> show (MapF.size $ SF.pfLiteralVars p)
+                    liftIO $ putStrLn $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
+                    let printedFormula = FO.printParameterizedFormula opWaveShape p
+                    liftIO $ putStrLn $ "printedFormula: " <> show printedFormula
+                    let fenv = undefined
+                    lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
+                    reForm <- liftIO $
+                              Log.withLogCfg lcfg $
+                              FI.readFormula sym fenv opWaveShape printedFormula
+                    liftIO $ putStrLn $ "re-Formulized: " <> show reForm
+                    case reForm of
+                      Left e -> ("read got error for: " <> show printedFormula) === e
+                      Right f -> do SF.pfUses p === SF.pfUses f
+                                    -- SF.pfOperandVars p === SF.pfOperandVars f
+                                    -- SF.pfLiteralVars p === SF.pfLiteralVars f
+                                    -- SF.pfDefs p === SF.pfDefs f
+
     ]
   ]
   where
-    isNatArgFoo :: TestOperand "NatArg:Foo" -> Bool
+    isNatArgFoo :: BV.BoundVar sym TestGenArch "Foo" -> Bool
     isNatArgFoo _ = True
     -- isValidParamType :: forall arch (m :: * -> *) (sh :: [ghc-prim-0.5.3:GHC.Types.Symbol]).
     --                     (L.IsLocation (L.Location arch), MonadTest m) =>
-    --                     Some (F.Parameter arch sh) -> m ()
+    --                     Some (SF.Parameter arch sh) -> m ()
     isValidParamType (Some param) =
-      case testEquality (F.paramType param) BaseNatRepr of
+      case testEquality (SF.paramType param) BaseNatRepr of
         Just Refl -> True
         Nothing ->
-          case testEquality (F.paramType param) BaseIntegerRepr of
+          case testEquality (SF.paramType param) BaseIntegerRepr of
             Just Refl -> True
             Nothing -> False

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -64,7 +64,7 @@ parameterizedFormulaTests = [
     , testProperty "serialized formula round trip" $
       property $ do Some r <- liftIO newIONonceGenerator
                     sym <- liftIO $ newSimpleBackend r
-                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    p <- forAllT (genParameterizedFormula @'["Bar"] sym)
                     debugPrint $ "parameterizedFormula: " <> show p
                     debugPrint $ "# literalVars: " <> show (MapF.size $ SF.pfLiteralVars p)
                     debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
@@ -86,7 +86,7 @@ parameterizedFormulaTests = [
                     sym <- liftIO $ newSimpleBackend r
                     lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
 
-                    p <- forAllT (genParameterizedFormula @'["Foo"] sym)
+                    p <- forAllT (genParameterizedFormula @'["Bar"] sym)
 
                     -- first round trip:
                     let printedFormula = FO.printParameterizedFormula opWaveShape p  -- KWQ: opWaveShape?!

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -107,7 +107,7 @@ parameterizedFormulaTests = [
                     f <- evalEither reForm
                     compareParameterizedFormulasSimply sym 1 p f
 
-    , testProperty "serialized formula round trip, online backend" $
+    , testProperty "serialized formula round trip, online backend, OpWave" $
       property $
       E.handleAll (\e -> annotate (show e) >> failure) $ do
         Some r <- liftIO newIONonceGenerator
@@ -134,7 +134,34 @@ parameterizedFormulaTests = [
           -- verify the recreated formula matches the original
           compareParameterizedFormulasSymbolically sym operands 1 p f
 
-    , testProperty "serialized formula double round trip" $
+    , testProperty "serialized formula round trip, online backend, OpPack" $
+      property $
+      E.handleAll (\e -> annotate (show e) >> failure) $ do
+        Some r <- liftIO newIONonceGenerator
+        CBO.withYicesOnlineBackend @(CBO.Flags CBO.FloatReal) r CBO.NoUnsatFeatures $ \sym -> do
+          -- generate a formula
+          let opcode = OpPack
+          (p, operands) <- forAllT (genParameterizedFormula sym opcode)
+          -- ensure that formula compares as equivalent to itself
+          compareParameterizedFormulasSymbolically sym operands 1 p p
+          -- now print the formula to a text string
+          debugPrint $ "parameterizedFormula: " <> show p
+          debugPrint $ "# literalVars: " <> show (MapF.size $ SF.pfLiteralVars p)
+          debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
+          let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
+          debugPrint $ "printedFormula: " <> show printedFormula
+          -- convert the printed text string back into a formula
+          let fenv = undefined
+          lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
+          reForm <- liftIO $
+                    Log.withLogCfg lcfg $
+                    FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
+          debugPrint $ "re-Formulized: " <> show reForm
+          f <- evalEither reForm
+          -- verify the recreated formula matches the original
+          compareParameterizedFormulasSymbolically sym operands 1 p f
+
+    , testProperty "serialized formula double round trip, OpWave" $
       property $
       E.handleAll (\e -> annotate (show e) >> failure) $ do
         Some r <- liftIO newIONonceGenerator
@@ -160,7 +187,37 @@ parameterizedFormulaTests = [
           f' <- evalEither reForm'
 
           -- verification of results
+          compareParameterizedFormulasSymbolically sym operands 1 p f
+          compareParameterizedFormulasSymbolically sym operands 1 f f'
           -- KWQ: is variable renaming OK as long as the renaming is consistent and non-overlapping?
+          compareParameterizedFormulasSymbolically sym operands 2 p f'
+
+    , testProperty "serialized formula double round trip, OpPack" $
+      property $
+      E.handleAll (\e -> annotate (show e) >> failure) $ do
+        Some r <- liftIO newIONonceGenerator
+        CBO.withYicesOnlineBackend @(CBO.Flags CBO.FloatReal) r CBO.NoUnsatFeatures $ \sym -> do
+          let opcode = OpPack
+          lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
+
+          (p, operands) <- forAllT (genParameterizedFormula sym opcode)
+
+          -- first round trip:
+          let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
+          let fenv = undefined
+          reForm <- liftIO $
+                    Log.withLogCfg lcfg $
+                    FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
+          f <- evalEither reForm
+
+          -- second round trip:
+          let printedFormula' = FO.printParameterizedFormula (HR.typeRepr opcode) f
+          reForm' <- liftIO $
+                     Log.withLogCfg lcfg $
+                     FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula'
+          f' <- evalEither reForm'
+
+          -- verification of results
           compareParameterizedFormulasSymbolically sym operands 1 p f
           compareParameterizedFormulasSymbolically sym operands 1 f f'
           compareParameterizedFormulasSymbolically sym operands 2 p f'

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -12,6 +12,7 @@ import qualified Control.Monad.Catch as E
 import           Control.Monad.IO.Class ( liftIO )
 import           Data.Maybe
 import           Data.Parameterized.Classes
+import qualified Data.Parameterized.HasRepr as HR
 import qualified Data.Parameterized.List as SL
 import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.Nonce
@@ -76,13 +77,13 @@ parameterizedFormulaTests = [
                     debugPrint $ "parameterizedFormula: " <> show p
                     debugPrint $ "# literalVars: " <> show (MapF.size $ SF.pfLiteralVars p)
                     debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
-                    let printedFormula = FO.printParameterizedFormula opWaveShape p
+                    let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
                     debugPrint $ "printedFormula: " <> show printedFormula
                     let fenv = undefined
                     lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
                     reForm <- liftIO $
                               Log.withLogCfg lcfg $
-                              FI.readFormula sym fenv opWaveShape printedFormula
+                              FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
                     debugPrint $ "re-Formulized: " <> show reForm
                     f <- evalEither reForm
                     compareParameterizedFormulasSimply sym 1 p f
@@ -101,14 +102,14 @@ parameterizedFormulaTests = [
           debugPrint $ "parameterizedFormula: " <> show p
           debugPrint $ "# literalVars: " <> show (MapF.size $ SF.pfLiteralVars p)
           debugPrint $ "# defs: " <> show (MapF.size $ SF.pfDefs p)
-          let printedFormula = FO.printParameterizedFormula opWaveShape p
+          let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
           debugPrint $ "printedFormula: " <> show printedFormula
           -- convert the printed text string back into a formula
           let fenv = undefined
           lcfg <- liftIO $ Log.mkLogCfg "rndtrip"
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
-                    FI.readFormula sym fenv opWaveShape printedFormula
+                    FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
           debugPrint $ "re-Formulized: " <> show reForm
           f <- evalEither reForm
           -- verify the recreated formula matches the original
@@ -125,18 +126,18 @@ parameterizedFormulaTests = [
           (p, operands) <- forAllT (genParameterizedFormula sym opcode)
 
           -- first round trip:
-          let printedFormula = FO.printParameterizedFormula opWaveShape p  -- KWQ: opWaveShape?!
+          let printedFormula = FO.printParameterizedFormula (HR.typeRepr opcode) p
           let fenv = undefined
           reForm <- liftIO $
                     Log.withLogCfg lcfg $
-                    FI.readFormula sym fenv opWaveShape printedFormula
+                    FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula
           f <- evalEither reForm
 
           -- second round trip:
-          let printedFormula' = FO.printParameterizedFormula opWaveShape f
+          let printedFormula' = FO.printParameterizedFormula (HR.typeRepr opcode) f
           reForm' <- liftIO $
                      Log.withLogCfg lcfg $
-                     FI.readFormula sym fenv opWaveShape printedFormula'
+                     FI.readFormula sym fenv (HR.typeRepr opcode) printedFormula'
           f' <- evalEither reForm'
 
           -- verification of results

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -78,7 +78,9 @@ parameterizedFormulaTests = [
                     debugPrint $ "re-Formulized: " <> show reForm
                     f <- evalEither reForm
                     on (===) SF.pfUses p f
-                    compareOperandLists 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
+                    compareOperandLists sym 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
+                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f)
+
     , testProperty "serialized formula double round trip" $
       property $ do Some r <- liftIO newIONonceGenerator
                     sym <- liftIO $ newSimpleBackend r
@@ -105,9 +107,12 @@ parameterizedFormulaTests = [
                     on (===) SF.pfUses p f
                     on (===) SF.pfUses p f'
                     on (===) SF.pfUses f f'
-                    compareOperandLists 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
-                    compareOperandLists 2 (SF.pfOperandVars p) (SF.pfOperandVars f')
-                    compareOperandLists 1 (SF.pfOperandVars f) (SF.pfOperandVars f')
+                    compareOperandLists sym 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
+                    compareOperandLists sym 2 (SF.pfOperandVars p) (SF.pfOperandVars f')
+                    compareOperandLists sym 1 (SF.pfOperandVars f) (SF.pfOperandVars f')
+                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f)
+                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f')
+                    compareLiteralVarMaps sym (SF.pfLiteralVars f) (SF.pfLiteralVars f)
 
     ]
   ]

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module ParamFormulaTests where
+
+import           Data.Parameterized.Classes
+import           Data.Parameterized.Some
+import qualified Data.Parameterized.List as SL
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import qualified SemMC.Formula.Formula as F
+import           TestArchPropGen
+import           What4.BaseTypes
+import           Hedgehog
+
+import           Prelude
+
+
+parameterizedFormulaTests :: [TestTree]
+parameterizedFormulaTests = [
+  testGroup "Parameterized Formulas" $
+
+    [ testProperty "parameter type" $
+      property $ do p <- forAll (genParameterizedFormula @'["NatArg:Foo"] TestSymbolicBackend)
+                    assert (all isValidParamType (F.pfUses p))
+    , testProperty "operand type" $
+      property $ do p <- forAll (genParameterizedFormula @'["NatArg:Foo"] TestSymbolicBackend)
+                    assert $ isNatArgFoo ((F.pfOperandVars p) SL.!! SL.index0)
+      -- TBD: needs other tests
+    ]
+  ]
+  where
+    isNatArgFoo :: TestOperand "NatArg:Foo" -> Bool
+    isNatArgFoo _ = True
+    -- isValidParamType :: forall arch (m :: * -> *) (sh :: [ghc-prim-0.5.3:GHC.Types.Symbol]).
+    --                     (L.IsLocation (L.Location arch), MonadTest m) =>
+    --                     Some (F.Parameter arch sh) -> m ()
+    isValidParamType (Some param) =
+      case testEquality (F.paramType param) BaseNatRepr of
+        Just Refl -> True
+        Nothing ->
+          case testEquality (F.paramType param) BaseIntegerRepr of
+            Just Refl -> True
+            Nothing -> False

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -171,9 +171,6 @@ parameterizedFormulaTests = [
   where
     isNatArgFoo :: BV.BoundVar sym TestGenArch "Foo" -> Bool
     isNatArgFoo _ = True
-    -- isValidParamType :: forall arch (m :: * -> *) (sh :: [ghc-prim-0.5.3:GHC.Types.Symbol]).
-    --                     (L.IsLocation (L.Location arch), MonadTest m) =>
-    --                     Some (SF.Parameter arch sh) -> m ()
     isValidParamType (Some param) =
       case testEquality (SF.paramType param) BaseNatRepr of
         Just Refl -> True

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -43,6 +43,11 @@ parameterizedFormulaTests = [
                     sym <- liftIO $ newSimpleBackend r
                     p <- forAllT (genParameterizedFormula @'["Foo"] sym)
                     assert (all isValidParamType (SF.pfUses p))
+    , testProperty "parameter type multiple" $
+      property $ do Some r <- liftIO newIONonceGenerator
+                    sym <- liftIO $ newSimpleBackend r
+                    p <- forAllT (genParameterizedFormula @'["Foo", "Bar"] sym)
+                    assert (all isValidParamType (SF.pfUses p))
     , testProperty "operand type" $
       property $ do Some r <- liftIO newIONonceGenerator
                     sym <- liftIO $ newSimpleBackend r

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -112,7 +112,7 @@ parameterizedFormulaTests = [
                     compareOperandLists sym 1 (SF.pfOperandVars f) (SF.pfOperandVars f')
                     compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f)
                     compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f')
-                    compareLiteralVarMaps sym (SF.pfLiteralVars f) (SF.pfLiteralVars f)
+                    compareLiteralVarMaps sym (SF.pfLiteralVars f) (SF.pfLiteralVars f')
 
     ]
   ]

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -9,7 +9,6 @@
 module ParamFormulaTests where
 
 import           Control.Monad.IO.Class ( liftIO )
-import           Data.Function ( on )
 import           Data.Maybe
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.List as SL
@@ -77,9 +76,7 @@ parameterizedFormulaTests = [
                               FI.readFormula sym fenv opWaveShape printedFormula
                     debugPrint $ "re-Formulized: " <> show reForm
                     f <- evalEither reForm
-                    on (===) SF.pfUses p f
-                    compareOperandLists sym 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
-                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f)
+                    compareParameterizedFormulas sym 1 p f
 
     , testProperty "serialized formula double round trip" $
       property $ do Some r <- liftIO newIONonceGenerator
@@ -104,15 +101,9 @@ parameterizedFormulaTests = [
                     f' <- evalEither reForm'
 
                     -- verification of results
-                    on (===) SF.pfUses p f
-                    on (===) SF.pfUses p f'
-                    on (===) SF.pfUses f f'
-                    compareOperandLists sym 1 (SF.pfOperandVars p) (SF.pfOperandVars f)
-                    compareOperandLists sym 2 (SF.pfOperandVars p) (SF.pfOperandVars f')
-                    compareOperandLists sym 1 (SF.pfOperandVars f) (SF.pfOperandVars f')
-                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f)
-                    compareLiteralVarMaps sym (SF.pfLiteralVars p) (SF.pfLiteralVars f')
-                    compareLiteralVarMaps sym (SF.pfLiteralVars f) (SF.pfLiteralVars f')
+                    compareParameterizedFormulas sym 1 p f
+                    compareParameterizedFormulas sym 1 f f'
+                    compareParameterizedFormulas sym 2 p f'
 
     ]
   ]

--- a/semmc/tests/semstore/ParamFormulaTests.hs
+++ b/semmc/tests/semstore/ParamFormulaTests.hs
@@ -96,4 +96,8 @@ parameterizedFormulaTests = [
         Nothing ->
           case testEquality (SF.paramType param) BaseIntegerRepr of
             Just Refl -> True
-            Nothing -> False
+            Nothing ->
+              let aBV32 = BaseBVRepr knownNat :: BaseTypeRepr (BaseBVType 32) in
+              case testEquality (SF.paramType param) aBV32 of
+                Just Refl -> True
+                Nothing -> False

--- a/semmc/tests/semstore/ParameterTests.hs
+++ b/semmc/tests/semstore/ParameterTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -36,6 +37,17 @@ parameterTests = [
                         Nothing -> assert False
       -- TBD: needs other tests
       ]
+
+    , testGroup "Register (32-bit)" $
+      [ testProperty "parameter type" $
+        property $ do p <- forAll $ genRegParameter
+                      let aBV32 = BaseBVRepr knownNat :: BaseTypeRepr (BaseBVType 32)
+                      case testEquality (F.paramType p) aBV32 of
+                        Just Refl -> success
+                        Nothing -> assert False
+        -- TBD: needs other tests
+      ]
+
     ]
 
   ]

--- a/semmc/tests/semstore/ParameterTests.hs
+++ b/semmc/tests/semstore/ParameterTests.hs
@@ -38,9 +38,9 @@ parameterTests = [
       -- TBD: needs other tests
       ]
 
-    , testGroup "Register (32-bit)" $
+    , testGroup "Box (32-bit BV)" $
       [ testProperty "parameter type" $
-        property $ do p <- forAll $ genRegParameter
+        property $ do p <- forAll $ genBoxParameter
                       let aBV32 = BaseBVRepr knownNat :: BaseTypeRepr (BaseBVType 32)
                       case testEquality (F.paramType p) aBV32 of
                         Just Refl -> success

--- a/semmc/tests/semstore/ParameterTests.hs
+++ b/semmc/tests/semstore/ParameterTests.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ParameterTests where
+
+import           Data.Parameterized.Classes
+import qualified SemMC.Architecture.Location as L
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import qualified SemMC.Formula.Formula as F
+import           TestArch
+import           TestArchPropGen
+import           What4.BaseTypes
+import           Hedgehog
+
+import           Prelude
+
+
+parameterTests :: [TestTree]
+parameterTests = [
+  testGroup "Parameter" $
+
+    [ testGroup "Nat" $
+      [ testProperty "parameter type" $
+        property $ do p <- forAll genNatParameter
+                      case testEquality (F.paramType p) BaseNatRepr of
+                        Just Refl -> success
+                        Nothing -> assert False
+      -- TBD: needs other tests
+      ]
+
+    , testGroup "Integer" $
+      [ testProperty "parameter type" $
+        property $ do p <- forAll $ genIntParameter
+                      case testEquality (F.paramType p) BaseIntegerRepr of
+                        Just Refl -> success
+                        Nothing -> assert False
+      -- TBD: needs other tests
+      ]
+    ]
+
+  ]

--- a/semmc/tests/semstore/ParameterTests.hs
+++ b/semmc/tests/semstore/ParameterTests.hs
@@ -5,11 +5,9 @@
 module ParameterTests where
 
 import           Data.Parameterized.Classes
-import qualified SemMC.Architecture.Location as L
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import qualified SemMC.Formula.Formula as F
-import           TestArch
 import           TestArchPropGen
 import           What4.BaseTypes
 import           Hedgehog

--- a/semmc/tests/semstore/SemStore.hs
+++ b/semmc/tests/semstore/SemStore.hs
@@ -1,36 +1,9 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 module Main where
 
-import           Data.Parameterized.Classes
-import qualified Data.Parameterized.Context as Ctx
-import qualified Data.Set as Set
-import           Data.Type.Equality
-import           GHC.TypeNats as TypeNats
 import           LocationsTests
 import           ParameterTests
 import           ParamFormulaTests
-import           Numeric.Natural
-import qualified SemMC.Architecture.Location as L
-import qualified SemMC.Formula as F
-import qualified SemMC.Formula.Env as FE
 import           Test.Tasty
-import           TestArch
-import           TestArchPropGen
-import           What4.BaseTypes
-import qualified What4.Expr.Builder as SB
 
 import           Prelude
 

--- a/semmc/tests/semstore/SemStore.hs
+++ b/semmc/tests/semstore/SemStore.hs
@@ -21,6 +21,7 @@ import           Data.Type.Equality
 import           GHC.TypeNats as TypeNats
 import           LocationsTests
 import           ParameterTests
+import           ParamFormulaTests
 import           Numeric.Natural
 import qualified SemMC.Architecture.Location as L
 import qualified SemMC.Formula as F
@@ -35,4 +36,4 @@ import           Prelude
 
 main :: IO ()
 main = defaultMain $ testGroup "Storable Semantics" $
-       locationTests <> parameterTests
+       locationTests <> parameterTests <> parameterizedFormulaTests

--- a/semmc/tests/semstore/SemStore.hs
+++ b/semmc/tests/semstore/SemStore.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Main where
+
+import           Data.Parameterized.Classes
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Set as Set
+import           Data.Type.Equality
+import           GHC.TypeNats as TypeNats
+import           LocationsTests
+import           Numeric.Natural
+import qualified SemMC.Architecture.Location as L
+import qualified SemMC.Formula as F
+import qualified SemMC.Formula.Env as FE
+import           Test.Tasty
+import           TestArch
+import           TestArchPropGen
+import           What4.BaseTypes
+import qualified What4.Expr.Builder as SB
+
+import           Prelude
+
+main :: IO ()
+main = defaultMain $ testGroup "Storable Semantics" $ locationTests

--- a/semmc/tests/semstore/SemStore.hs
+++ b/semmc/tests/semstore/SemStore.hs
@@ -20,6 +20,7 @@ import qualified Data.Set as Set
 import           Data.Type.Equality
 import           GHC.TypeNats as TypeNats
 import           LocationsTests
+import           ParameterTests
 import           Numeric.Natural
 import qualified SemMC.Architecture.Location as L
 import qualified SemMC.Formula as F
@@ -33,4 +34,5 @@ import qualified What4.Expr.Builder as SB
 import           Prelude
 
 main :: IO ()
-main = defaultMain $ testGroup "Storable Semantics" $ locationTests
+main = defaultMain $ testGroup "Storable Semantics" $
+       locationTests <> parameterTests

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -62,25 +62,6 @@ readTestLocation _ = Nothing
 deriving instance Eq (TestLocation tp)
 deriving instance Ord (TestLocation tp)
 
-instance TestEquality TestLocation where
-  TestNatLoc l1 `testEquality` TestNatLoc l2 | l1 == l2 = Just Refl
-                                             | otherwise = Nothing
-  TestIntLoc l1 `testEquality` TestIntLoc l2 | l1 == l2 = Just Refl
-                                             | otherwise = Nothing
-  TestRegLoc l1 `testEquality` TestRegLoc l2 | l1 == l2 = Just Refl
-                                             | otherwise = Nothing
-  _ `testEquality` _ = Nothing
-
-instance OrdF TestLocation where
-  TestNatLoc l1 `compareF` TestNatLoc l2 = fromOrdering $ l1 `compare` l2
-  TestIntLoc l1 `compareF` TestIntLoc l2 = fromOrdering $ l1 `compare` l2
-  TestRegLoc l1 `compareF` TestRegLoc l2 = fromOrdering $ l1 `compare` l2
-  -- for mismatched location types, arbitrarily: any Int < any Nat < any Reg
-  TestNatLoc _ `compareF` TestIntLoc _ = GTF
-  TestRegLoc _ `compareF` TestIntLoc _ = GTF
-  TestRegLoc _ `compareF` TestNatLoc _ = GTF
-  _ `compareF` _ = LTF
-
 instance L.IsLocation TestLocation where
   locationType (TestNatLoc _) = BaseNatRepr
   locationType (TestIntLoc _) = BaseIntegerRepr
@@ -109,12 +90,6 @@ deriving instance Show (TestGenOperand nm)
 instance ShowF TestGenOperand
   where
     showF _ = "<<OPERAND>>"
-instance TestEquality TestGenOperand where
-  FooArg `testEquality` FooArg = Just Refl
-
-instance OrdF TestGenOperand where
-  compareF FooArg FooArg = EQF
-
 -- data TestGenOperandType (operand :: Symbol) where
 --   "Wave" :: TestGenOpcodeType "Wave"
 
@@ -122,11 +97,6 @@ data TestGenOpcode (operand_constr :: Symbol -> Type) (operands :: [Symbol]) whe
   OpWave :: TestGenOpcode TestGenOperand '["Foo"]
 
 deriving instance Show (TestGenOpcode operand_constr operands)
-
-$(return [])
-
-instance TestEquality (TestGenOpcode operand_constr) where
-  testEquality = $(TH.structuralTypeEquality [t| TestGenOpcode |] [])
 
 opWaveShape :: List TestGenOperand '["Foo"]
 opWaveShape = FooArg :< PL.Nil
@@ -156,3 +126,23 @@ instance OrdF (TestGenOpcode TestGenOperand)
 
 -- S (What4.Interface):
 -- type family BoundVar (sym :: Type) :: BaseType -> Type
+
+----------------------------------------------------------------------
+-- TestEquality and OrdF instances
+
+$(return [])
+
+instance TestEquality TestGenOperand where
+  testEquality = $(TH.structuralTypeEquality [t| TestGenOperand |] [])
+
+instance OrdF TestGenOperand where
+  compareF = $(TH.structuralTypeOrd [t| TestGenOperand |] [])
+
+instance TestEquality (TestGenOpcode operand_constr) where
+  testEquality = $(TH.structuralTypeEquality [t| TestGenOpcode |] [])
+
+instance TestEquality TestLocation where
+  testEquality = $(TH.structuralTypeEquality [t| TestLocation |] [])
+
+instance OrdF TestLocation where
+  compareF = $(TH.structuralTypeOrd [t| TestLocation |] [])

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -88,12 +88,15 @@ data TestLocation :: BaseType -> Type where
   -- TBD: some memory locations
   -- MemLoc :: Mem -> Location (BaseBVType 32)
 
+-- Specifies the serialized S-expression form of these locations.
+-- These must be valid S-expression symbols: alphanumeric and
+-- underscores only.
 instance Show (TestLocation tp) where
   show TestBarLoc     = "Bar"
   show (TestBoxLoc n) = "Box_" <> show n
-  show (TestNatLoc n) = "NAT_" <> show n  -- KWQ: want NAT@... see above
+  show (TestNatLoc n) = "NAT_" <> show n
   show (TestIntLoc i) = if i >= 0
-                        then "INT_" <> show i  -- KWQ: want INT@... see above
+                        then "INT_" <> show i
                         else "NEGINT_" <> show (-i)
 
 instance ShowF TestLocation
@@ -145,9 +148,9 @@ data TestGenOperand (nm::Symbol) where
 deriving instance Show (TestGenOperand nm)
 instance ShowF TestGenOperand
   where
+    -- once it's clear where this is needed, a more descriptive form
+    -- can be provided.
     showF _ = "<<OPERAND>>"
--- data TestGenOperandType (operand :: Symbol) where
---   "Wave" :: TestGenOpcodeType "Wave"
 
 data TestGenOpcode (operand_constr :: Symbol -> Type) (operands :: [Symbol]) where
   OpWave :: TestGenOpcode TestGenOperand '["Bar"]
@@ -176,6 +179,8 @@ instance SA.IsOperandTypeRepr TestGenArch where
 
 instance ShowF (TestGenOpcode TestGenOperand)
   where
+    -- once it's clear where this is needed, a more descriptive form
+    -- can be provided.
     showF _ = "<<OPCODE>>"
 instance EnumF (TestGenOpcode TestGenOperand) where
 instance OrdF (TestGenOpcode TestGenOperand)

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -15,11 +15,12 @@ where
 import           Data.Kind ( Type )
 import           Data.Parameterized.Classes
 import           Numeric.Natural
+import qualified SemMC.Architecture as SA
 import qualified SemMC.Architecture.Location as L
 import           What4.BaseTypes
 
 
-data TestGenArch
+data TestGenArch  -- ^ the architecture type for testing
 
 ----------------------------------------------------------------------
 -- Location
@@ -58,3 +59,9 @@ instance L.IsLocation TestLocation where
 
 
 type instance L.Location TestGenArch = TestLocation
+
+
+----------------------------------------------------------------------
+-- Operands
+
+type instance SA.OperandType TestGenArch "NatArg:Foo" = BaseNatType

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -49,6 +49,9 @@ instance TestEquality TestLocation where
 instance OrdF TestLocation where
   TestNatLoc l1 `compareF` TestNatLoc l2 = fromOrdering $ l1 `compare` l2
   TestIntLoc l1 `compareF` TestIntLoc l2 = fromOrdering $ l1 `compare` l2
+  -- for mismatched location types, arbitrarily: any Int < any Nat
+  TestIntLoc _ `compareF` TestNatLoc _ = LTF
+  TestNatLoc _ `compareF` TestIntLoc _ = GTF
   -- _ `compareF` _ = LTF
 
 instance L.IsLocation TestLocation where

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-| Minimal definition of a test architecture which allows various
+  testing to be performed.  Not a real architecture at all... not even
+  a little bit.
+|-}
+
+module TestArch
+where
+
+import           Data.Kind ( Type )
+import           Data.Parameterized.Classes
+import           Numeric.Natural
+import qualified SemMC.Architecture.Location as L
+import           What4.BaseTypes
+
+
+data TestGenArch
+
+----------------------------------------------------------------------
+-- Location
+
+data TestLocation :: BaseType -> Type where
+  TestNatLoc :: Natural -> TestLocation BaseNatType
+  TestIntLoc :: Integer -> TestLocation BaseIntegerType
+  -- TBD: more basetype locations
+  -- TBD: some memory locations
+  -- MemLoc :: Mem -> Location (BaseBVType 32)
+
+deriving instance Show (TestLocation tp)
+deriving instance Eq (TestLocation tp)
+deriving instance Ord (TestLocation tp)
+
+instance ShowF TestLocation where
+  showF = show
+
+instance TestEquality TestLocation where
+  TestNatLoc l1 `testEquality` TestNatLoc l2 | l1 == l2 = Just Refl
+                                             | otherwise = Nothing
+  TestIntLoc l1 `testEquality` TestIntLoc l2 | l1 == l2 = Just Refl
+                                             | otherwise = Nothing
+  _ `testEquality` _ = Nothing
+
+instance OrdF TestLocation where
+  TestNatLoc l1 `compareF` TestNatLoc l2 = fromOrdering $ l1 `compare` l2
+  TestIntLoc l1 `compareF` TestIntLoc l2 = fromOrdering $ l1 `compare` l2
+  -- _ `compareF` _ = LTF
+
+instance L.IsLocation TestLocation where
+  locationType (TestNatLoc _) = BaseNatRepr
+  locationType (TestIntLoc _) = BaseIntegerRepr
+
+  isMemoryLocation _ = False
+
+
+type instance L.Location TestGenArch = TestLocation

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -148,6 +148,7 @@ data TestGenOpcode (operand_constr :: Symbol -> Type) (operands :: [Symbol]) whe
   OpWave :: TestGenOpcode TestGenOperand '["Bar"]
   OpSurf :: TestGenOpcode TestGenOperand '["Foo"]
   OpPack :: TestGenOpcode TestGenOperand '["Box", "Bar", "Box", "Box"]
+  OpSolo :: TestGenOpcode TestGenOperand '[]
 
 deriving instance Show (TestGenOpcode operand_constr operands)
 
@@ -155,6 +156,7 @@ instance HR.HasRepr (TestGenOpcode TestGenOperand) (PL.List SR.SymbolRepr) where
   typeRepr OpWave = knownRepr
   typeRepr OpSurf = knownRepr
   typeRepr OpPack = knownRepr
+  typeRepr OpSolo = knownRepr
 
 
 type instance SA.Opcode TestGenArch = TestGenOpcode

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -2,9 +2,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-| Minimal definition of a test architecture which allows various
@@ -18,6 +21,7 @@ where
 import           Data.EnumF -- in Dismantle Tablegen!
 import           Data.Kind ( Type )
 import           Data.Parameterized.Classes
+import qualified Data.Parameterized.HasRepr as HR
 import           Data.Parameterized.List ( List( (:<) ) )
 import qualified Data.Parameterized.List as PL
 import           Data.Parameterized.Some
@@ -138,8 +142,9 @@ data TestGenOpcode (operand_constr :: Symbol -> Type) (operands :: [Symbol]) whe
 
 deriving instance Show (TestGenOpcode operand_constr operands)
 
-opWaveShape :: List (SA.OperandTypeRepr TestGenArch) '["Bar"]
-opWaveShape = SR.knownSymbol :< PL.Nil
+instance HR.HasRepr (TestGenOpcode TestGenOperand) (PL.List SR.SymbolRepr) where
+  typeRepr OpWave = knownRepr
+  typeRepr OpSurf = knownRepr
 
 type instance SA.Opcode TestGenArch = TestGenOpcode
 type instance SA.Operand TestGenArch = TestGenOperand

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -64,7 +64,8 @@ instance SA.Architecture TestGenArch where
           -> BaseBVRepr (knownNat :: NatRepr 32)
       _ -> error ("Invalid shape repr: " ++ show sr)
 
-  allocateSymExprsForOperand _arch _sym newVars FooArg = undefined
+  allocateSymExprsForOperand _arch _sym _newVars FooArg =
+    error "allocateSymExprsForOperand FooArg TBD"
   allocateSymExprsForOperand _arch _sym newVars BarArg =
     let loc = TestBarLoc in
     TaggedExpr <$> SA.LocationOperand loc <$> newVars loc
@@ -120,6 +121,10 @@ instance L.IsLocation TestLocation where
                  <> (Some . TestBoxLoc <$> [0..3])
                  <> (Some . TestNatLoc <$> [0..6])
                  <> (Some . TestIntLoc <$> [-10..10])
+
+  defaultLocationExpr = error "TestLocation defaultLocationExpr TBD"
+
+  registerizationLocations = error "TestLocation registerizationLocations TBD"
 
 
 type instance L.Location TestGenArch = TestLocation

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-| Minimal definition of a test architecture which allows various
@@ -19,6 +20,7 @@ import           Data.Parameterized.Classes
 import           Data.Parameterized.List ( List( (:<) ) )
 import qualified Data.Parameterized.List as PL
 import           Data.Parameterized.Some
+import qualified Data.Parameterized.TH.GADT as TH
 import           GHC.TypeLits ( Symbol )
 import           Numeric.Natural
 import qualified SemMC.Architecture as SA
@@ -116,14 +118,15 @@ instance OrdF TestGenOperand where
 -- data TestGenOperandType (operand :: Symbol) where
 --   "Wave" :: TestGenOpcodeType "Wave"
 
-data TestGenOpcode (operand_type :: Symbol -> Type) (opcodes :: [Symbol]) where
-  OpWave :: TestGenOpcode TestGenOperand '[]
-  -- TestGenOperand ["Wave"] = OpWave
+data TestGenOpcode (operand_constr :: Symbol -> Type) (operands :: [Symbol]) where
+  OpWave :: TestGenOpcode TestGenOperand '["Foo"]
 
-deriving instance Show (TestGenOpcode operand_type opcodes)
+deriving instance Show (TestGenOpcode operand_constr operands)
 
-instance TestEquality (TestGenOpcode operand_type) where
-  OpWave `testEquality` OpWave = Just Refl
+$(return [])
+
+instance TestEquality (TestGenOpcode operand_constr) where
+  testEquality = $(TH.structuralTypeEquality [t| TestGenOpcode |] [])
 
 opWaveShape :: List TestGenOperand '["Foo"]
 opWaveShape = FooArg :< PL.Nil

--- a/semmc/tests/semstore/TestArch.hs
+++ b/semmc/tests/semstore/TestArch.hs
@@ -22,7 +22,6 @@ import           Data.EnumF -- in Dismantle Tablegen!
 import           Data.Kind ( Type )
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.HasRepr as HR
-import           Data.Parameterized.List ( List( (:<) ) )
 import qualified Data.Parameterized.List as PL
 import           Data.Parameterized.Some
 import qualified Data.Parameterized.SymbolRepr as SR
@@ -129,9 +128,6 @@ type instance L.Location TestGenArch = TestLocation
 ----------------------------------------------------------------------
 -- Operands
 
--- type ShapeRepr arch = SL.List (OperandTypeRepr arch)
--- type family OperandType (arch::Type) (op[erand]::Symbol) :: BaseType
-
 type instance SA.OperandType TestGenArch "Foo" = BaseNatType  -- unsupported for Printer
 type instance SA.OperandType TestGenArch "Bar" = BaseBVType 32
 type instance SA.OperandType TestGenArch "Box" = BaseBVType 32
@@ -169,20 +165,13 @@ instance SA.IsOpcode TestGenOpcode
 
 instance SA.IsOperandTypeRepr TestGenArch where
   type OperandTypeRepr TestGenArch = SR.SymbolRepr
-  operandTypeReprSymbol arch = T.unpack . SR.symbolRepr
+  operandTypeReprSymbol _arch = T.unpack . SR.symbolRepr
 
 instance ShowF (TestGenOpcode TestGenOperand)
   where
     showF _ = "<<OPCODE>>"
 instance EnumF (TestGenOpcode TestGenOperand) where
 instance OrdF (TestGenOpcode TestGenOperand)
-
--- BV :: SemMC.BoundVar
--- newtype BoundVar (sym :: Type) (arch :: Type) (op :: Symbol) =
---   BoundVar { unBoundVar :: S.BoundVar sym (OperandType arch op) }
-
--- S (What4.Interface):
--- type family BoundVar (sym :: Type) :: BaseType -> Type
 
 ----------------------------------------------------------------------
 -- TestEquality and OrdF instances

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -115,8 +115,9 @@ genRegParameter = HG.choice
 genSomeParameter :: Monad m => GenT m (Some (F.Parameter TestGenArch sh))
 genSomeParameter =
   HG.choice
-  [ Some <$> genNatParameter
-  , Some <$> genIntParameter
+  [
+    -- Some <$> genNatParameter  -- not supported for formula printing
+    -- , Some <$> genIntParameter  -- not supported for formula printing
     Some <$> genRegParameter
   ]
 

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module TestArchPropGen
+where
+
+import           Data.Int ( Int64 )
+import           Hedgehog
+import qualified Hedgehog.Gen as HG
+import           Hedgehog.Range
+import           Numeric.Natural
+import qualified SemMC.Formula.Formula as F
+import           TestArch
+import           What4.BaseTypes
+
+
+genNat :: Monad m => GenT m Natural
+genNat = HG.frequency [ (5, return 0)
+                      , (5, return 1)
+                      , (90, toEnum . abs <$> HG.int (linearBounded :: Range Int))
+                      ]
+         -- Ensures that 0 and 1 are present in any reasonably-sized distribution
+
+----------------------------------------------------------------------
+-- Location Generators
+
+genNatLocation :: Monad m => GenT m (TestLocation BaseNatType)
+genNatLocation = TestNatLoc <$> genNat
+
+genIntLocation :: Monad m => GenT m (TestLocation BaseIntegerType)
+genIntLocation = TestIntLoc <$>
+                 HG.frequency [ (5, return 0)
+                              , (5, return 1)
+                              , (90, fromInteger . toEnum . fromEnum <$>
+                                     HG.integral (linearBounded :: Range Int64))
+                              ]
+                 -- Ensures that 0 and 1 are present in any reasonably-sized distribution
+
+----------------------------------------------------------------------
+-- Function.Parameter Generators
+
+genNatParameter :: Monad m => GenT m (F.Parameter TestGenArch sh BaseNatType)
+genNatParameter = HG.choice
+                  [
+                    -- , F.OperandParameter :: BaseTypeRepr (A.OperandType arch s) -> SL.Index sh s -> Parameter arch sh (A.OperandType arch s)
+                    F.LiteralParameter <$> genNatLocation
+                    -- , FunctionParameter :: String
+                    -- -- The name of the uninterpreted function
+                    -- -> WrappedOperand arch sh s
+                    -- -- The operand we are calling the function on (this is a newtype so
+                    -- -- we don't need an extra typerepr)
+                    -- -> BaseTypeRepr tp
+                    -- -- The typerepr for the return type of the function
+                    -- -> Parameter arch sh tp
+                  ]
+
+-- instance Arbitrary (F.Parameter TestGenArch sh BaseNatType) where
+--   arbitrary = oneof [ undefined -- return $ F.OperandParameter oprepr1 undefined
+--                     , F.LiteralParameter <$> arbitrary
+--                     -- , return $ F.FunctionParameter undefined undefined oprepr2
+--                     ]
+--               where oprepr1 = undefined
+--                     oprepr2 = undefined
+--                     -- loc :: TestLocation ty
+--                     -- loc = arbitrary
+
+-- instance Arbitrary (F.Parameter TestGenArch sh BaseIntegerType) where
+--   arbitrary = oneof [ undefined -- return $ F.OperandParameter oprepr1 undefined
+--                     , F.LiteralParameter <$> arbitrary
+--                     -- , return $ F.FunctionParameter undefined undefined oprepr2
+--                     ]
+--               where oprepr1 = undefined
+--                     oprepr2 = undefined
+--                     -- loc :: TestLocation ty
+--                     -- loc = arbitrary
+
+----------------------------------------------------------------------
+-- Formula.ParameterizedFormula generators
+
+genParameterizedFormula :: Monad m => GenT m (F.ParameterizedFormula sym TestGenArch sh)
+genParameterizedFormula =
+  HG.element
+  [
+    -- TBD!
+  ]

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -1,16 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module TestArchPropGen
 where
 
+import           Control.Monad.IO.Class
 import           Data.Int ( Int64 )
+import           Data.Parameterized.Classes
+import qualified Data.Parameterized.List as SL
+import           Data.Parameterized.Nonce ( newIONonceGenerator )
+import           Data.Parameterized.Some
+import qualified Data.Set as Set
+import           GHC.TypeLits ( Symbol )
 import           Hedgehog
 import qualified Hedgehog.Gen as HG
 import           Hedgehog.Range
 import           Numeric.Natural
+import qualified SemMC.Architecture as SA
+import qualified SemMC.BoundVar as BV
 import qualified SemMC.Formula.Formula as F
 import           TestArch
 import           What4.BaseTypes
+import qualified What4.Expr.Builder as WB
+import qualified What4.Interface as WI
 
 
 genNat :: Monad m => GenT m Natural
@@ -68,13 +87,85 @@ genIntParameter = HG.choice
                     -- -> Parameter arch sh tp
                   ]
 
+genSomeParameter :: Monad m => GenT m (Some (F.Parameter TestGenArch sh))
+genSomeParameter =
+  HG.choice
+  [ Some <$> genNatParameter
+  , Some <$> genIntParameter
+  ]
+
+
+----------------------------------------------------------------------
+
+-- data TestSymLocation :: BaseType -> Type where
+--   TestSymLocation :: TestSymBackend
+data TestSymExpr (ty :: BaseType) = TestSymExpr
+  deriving Show
+
+instance ShowF TestSymExpr
+
+data TestBoundVar (th :: BaseType) = TestBoundVar
+  deriving Show
+
+instance ShowF TestBoundVar
+
+data TestSymbolicBackend = TestSymbolicBackend
+ deriving Show
+
+type instance WI.SymExpr TestSymbolicBackend = TestSymExpr
+type instance WI.BoundVar TestSymbolicBackend = TestBoundVar
+
+type TestOperand = BV.BoundVar TestSymbolicBackend TestGenArch
+
+
+----------------------------------------------------------------------
+-- What4.Interface.BoundVar generators
+
+  -- KWQ: proxy sym?
+genBoundNatVar :: Monad m => GenT m (WI.BoundVar TestSymbolicBackend BaseNatType)
+genBoundNatVar = return TestBoundVar
+
+genBoundIntVar :: Monad m => GenT m (WI.BoundVar TestSymbolicBackend BaseIntegerType)
+genBoundIntVar = return TestBoundVar
+
+genBoundVar_NatArgFoo :: Monad m => GenT m (BV.BoundVar TestSymbolicBackend TestGenArch "NatArg:Foo")
+genBoundVar_NatArgFoo = BV.BoundVar <$> genBoundNatVar
 
 ----------------------------------------------------------------------
 -- Formula.ParameterizedFormula generators
 
-genParameterizedFormula :: Monad m => GenT m (F.ParameterizedFormula sym TestGenArch sh)
-genParameterizedFormula =
-  HG.element
-  [
-    -- TBD!
-  ]
+  -- KWQ: proxy sym?
+genParameterizedFormula :: forall sh sym m .  -- reordered args to allow TypeApplication of sh first
+                           ( Monad m
+                           , TestSymbolicBackend ~ sym
+                           , MkOperands (GenT m) (SL.List TestOperand) sh
+                           ) =>
+                           sym
+                        -> GenT m (F.ParameterizedFormula sym TestGenArch (sh :: [Symbol]))
+genParameterizedFormula _ = do
+  params <- Set.fromList <$> HG.list (linear 0 10) genSomeParameter
+  operandVars <- mkOperand -- SL.List (BV.BoundVar sym arch) sh
+  return F.ParameterizedFormula { F.pfUses = params
+                                , F.pfOperandVars = operandVars
+                                , F.pfLiteralVars = undefined
+                                , F.pfDefs = undefined
+                                }
+
+
+--------------------------------------------------------------------------------
+-- Helpers to generate the operandVars based on the caller-specified
+-- ParameterizedFormula 'sh'
+
+class Monad m => MkOperands m (f :: k -> *) (ctx :: k) where
+  mkOperand :: m (f ctx)
+
+instance (Monad m) => MkOperands m (SL.List TestOperand) '[] where
+  mkOperand = return SL.Nil
+instance (Monad m, MkOperands m TestOperand o, MkOperands m (SL.List TestOperand) os) =>
+  MkOperands m (SL.List TestOperand) (o ': os) where
+  mkOperand = do opl <- mkOperand
+                 opr <- mkOperand
+                 return $ opl SL.:< opr
+
+instance (Monad m) => MkOperands (GenT m) TestOperand "NatArg:Foo" where
+  mkOperand = genBoundVar_NatArgFoo

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -245,7 +245,6 @@ genBV32SymExpr :: ( MonadIO m
                   , WI.IsSymExprBuilder sym
                   , SA.IsLocation (SA.Location arch)
                   , SA.Location arch ~ TestLocation
---                  , KnownRepr BaseTypeRepr bt
                   ) =>
                   sym
                -> Set.Set (Some (F.Parameter arch sh))
@@ -269,7 +268,80 @@ genBV32SymExpr sym params opvars litvars = do
 
   HG.recursive HG.choice nonrecursive
     [ -- recursive
-      HG.subtermM (genBV32SymExpr sym params opvars litvars) (\t -> liftIO $ WI.bvNeg sym t)
+      HG.subtermM
+      (genBV32SymExpr sym params opvars litvars)
+      (\t -> liftIO $ WI.bvNeg sym t)
+
+    , HG.subtermM
+      (genBV32SymExpr sym params opvars litvars)
+      (liftIO . WI.bvNotBits sym)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvAdd sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvSub sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvMul sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvUdiv sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvUrem sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvSdiv sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvSrem sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvAndBits sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvOrBits sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvXorBits sym x y)
+
+    -- unhandled App in Printer.hs:232
+    -- , HG.subtermM
+    --   (genBV32SymExpr sym params opvars litvars)
+    --   (liftIO . WI.bvPopcount sym)
+
+    -- unhandled App in Printer.hs:232
+    -- , HG.subtermM
+    --   (genBV32SymExpr sym params opvars litvars)
+    --   (liftIO . WI.bvCountLeadingZeros sym)
+
+    -- unhandled App in Printer.hs:232
+    -- , HG.subtermM
+    --   (genBV32SymExpr sym params opvars litvars)
+    --   (liftIO . WI.bvCountTrailingZeros sym)
+
+    -- , (liftIO . WI.bvNeg sym) =<< genBV32SymExpr sym
     ]
 
 

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -120,46 +120,14 @@ genSomeParameter :: Monad m => GenT m (Some (F.Parameter TestGenArch sh))
 genSomeParameter =
   HG.choice
   [
-    -- Some <$> genNatParameter  -- not supported for formula printing
-    -- , Some <$> genIntParameter  -- not supported for formula printing
     Some <$> genRegParameter
+    -- , Some <$> genNatParameter  -- not supported for formula printing
+    -- , Some <$> genIntParameter  -- not supported for formula printing
   ]
 
 
 ----------------------------------------------------------------------
-
--- data TestSymLocation :: BaseType -> Type where
---   TestSymLocation :: TestSymBackend
-
-
-----------------------------------------------------------------------
--- What4.Interface.BoundVar generators
-
-{-
-data TestBoundVar (th :: BaseType) = TestBoundVar
-  deriving Show
-
-instance ShowF TestBoundVar
-type instance WI.BoundVar TestSymbolicBackend = TestBoundVar
-
-genBoundNatVar :: Monad m => GenT m (WI.BoundVar TestSymbolicBackend BaseNatType)
-genBoundNatVar = return TestBoundVar
-
-genBoundIntVar :: Monad m => GenT m (WI.BoundVar TestSymbolicBackend BaseIntegerType)
-genBoundIntVar = return TestBoundVar
-
-genBoundVar_NatArgFoo :: Monad m => GenT m (BV.BoundVar TestSymbolicBackend TestGenArch "NatArg:Foo")
-genBoundVar_NatArgFoo = BV.BoundVar <$> genBoundNatVar
--}
-
-------------------------------
-
-  -- KWQ: proxy sym? pass sym?
--- genBoundNatVar :: Monad m => sym -> GenT m (WI.BoundVar sym BaseNatType)
--- genBoundNatVar _ = return TestBoundVar
-
--- genBoundIntVar :: Monad m => sym -> GenT m (WI.BoundVar sym BaseIntegerType)
--- genBoundIntVar _ = return TestBoundVar
+-- SolverSymbol Generators
 
 genSolverSymbol :: Monad m => GenT m WI.SolverSymbol
 genSolverSymbol = HG.choice [ -- return WI.emptySymbol  -- KWQ: generates eqns with this, but the eqns are invalid!
@@ -238,10 +206,6 @@ genBoundVar_NatArgFoo :: Monad m => MonadIO m =>
                          WI.IsSymExprBuilder sym =>
                          sym -> GenT m (TestBoundVar sym "Foo")
 genBoundVar_NatArgFoo sym = BV.BoundVar <$> genBoundNatVar sym Nothing  -- KWQ: generic genBoundVar?
--- genBoundVar_NatArgFoo sym =
---   do bnv <- genBoundNatVar sym  -- KWQ: generic genBoundVar?
---      liftIO $ putStrLn
---      return BV.BoundVar bnv
 
 ----------------------------------------------------------------------
 -- What4.Interface.SymExpr generators
@@ -295,13 +259,13 @@ varExprBV32 :: (WI.IsSymExprBuilder sym) =>
             -> MapF.MapF TestLocation (WI.BoundVar sym)
             -> Some TestLocation
             -> WI.SymBV sym 32
-            -- -> WI.SymExpr sym (BaseBVType 32)
 varExprBV32 sym litvars (Some key) =
   case SA.locationType key of
     (BaseBVRepr w) ->
       case testEquality w (knownNat :: NatRepr 32) of
         Just Refl -> WI.varExpr sym $ fromJust' "varExprBV32.BVRepr32.lookup" $ MapF.lookup key litvars
         Nothing -> error $ "varExprBV32 unsupported BVRepr size: " <> show w
+
 
 ----------------------------------------------------------------------
 -- Formula.ParameterizedFormula generators

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -38,12 +38,13 @@ import qualified SemMC.BoundVar as BV
 import qualified SemMC.Formula.Formula as F
 import           SemMC.Util ( fromJust' )
 import           TestArch
-import           TestUtils
 import           What4.BaseTypes
 import qualified What4.Expr.Builder as WE
 import qualified What4.Interface as WI
 import           What4.Symbol ( systemSymbol )
 
+
+----------------------------------------------------------------------
 
 genNat :: Monad m => GenT m Natural
 genNat = HG.frequency [ (5, return 0)
@@ -351,33 +352,25 @@ genParameterizedFormula sym = do
                                genExpr sym p params operandVars literalVars
                in MapF.fromList <$> HG.list (linear 0 10) anElem
   return F.ParameterizedFormula
-    { F.pfUses = params
+    { F.pfUses = params              -- Set.Set (Some (Parameter arch sh))
     , F.pfOperandVars = operandVars  -- PL.List (BV.BoundVar sym arch) sh
     , F.pfLiteralVars = literalVars  -- MapF.MapF (L.Location arch) (WI.BoundVar sym)
-    , F.pfDefs = defs  -- MapF.MapF (Parameter arch sh) (WI.SymExpr sym)
+    , F.pfDefs = defs                -- MapF.MapF (Parameter arch sh) (WI.SymExpr sym)
     }
 
 
 possibleInput :: ( WI.IsSymExprBuilder sym
                  , WI.IsExprBuilder sym
-                , WI.BoundVar sym ~ WE.ExprBoundVar t
+                 , WI.BoundVar sym ~ WE.ExprBoundVar t
                  ) =>
                  PL.Index sh tp
               -> BV.BoundVar sym TestGenArch tp
               -> ([Bool], [Some (F.Parameter TestGenArch sh)])
               -> ([Bool], [Some (F.Parameter TestGenArch sh)])
 possibleInput idx opBV (isInput:r, inps) =
-  let inpParam = Some $
-                 F.OperandParameter
-                 -- (inpTy opBV)
-                 -- knownRepr
-                 (WE.bvarType $ BV.unBoundVar opBV)
-                 idx
-      -- inpTy :: BaseTypeRepr (SA.OperandType TestGenArch sh)
-      -- inpTy = undefined
-      -- inpTy = SA.shapeReprToTypeRepr TestGenArch undefined
+  let inpParam = F.OperandParameter (WE.bvarType $ BV.unBoundVar opBV) idx
   in if isInput
-     then (r, inpParam : inps)
+     then (r, Some inpParam : inps)
      else (r, inps)
 possibleInput _ _ a = a
 

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -41,7 +41,7 @@ import           TestArch
 import           What4.BaseTypes
 import qualified What4.Expr.Builder as WE
 import qualified What4.Interface as WI
-import           What4.Symbol ( systemSymbol, solverSymbolAsText )
+import           What4.Symbol ( systemSymbol )
 
 
 ----------------------------------------------------------------------
@@ -69,8 +69,8 @@ genIntLocation = TestIntLoc <$>
                               ]
                  -- Ensures that 0 and 1 are present in any reasonably-sized distribution
 
-genRegLocation :: Monad m => GenT m (TestLocation (BaseBVType 32))
-genRegLocation = TestBoxLoc <$> HG.element [0..3]
+genBoxLocation :: Monad m => GenT m (TestLocation (BaseBVType 32))
+genBoxLocation = TestBoxLoc <$> HG.element [0..3]
 
 ----------------------------------------------------------------------
 -- Function.Parameter Generators
@@ -105,11 +105,11 @@ genIntParameter = HG.choice
                     -- -> Parameter arch sh tp
                   ]
 
-genRegParameter :: Monad m => GenT m (F.Parameter TestGenArch sh (BaseBVType 32))
-genRegParameter = HG.choice
+genBoxParameter :: Monad m => GenT m (F.Parameter TestGenArch sh (BaseBVType 32))
+genBoxParameter = HG.choice -- KWQ: more of theses!
                   [
                     -- , F.OperandParameter :: BaseTypeRepr (A.OperandType arch s) -> PL.Index sh s -> Parameter arch sh (A.OperandType arch s)
-                    F.LiteralParameter <$> genRegLocation
+                    F.LiteralParameter <$> genBoxLocation
                     -- , FunctionParameter :: String
                     -- -- The name of the uninterpreted function
                     -- -> WrappedOperand arch sh s
@@ -124,7 +124,7 @@ genSomeParameter :: Monad m => GenT m (Some (F.Parameter TestGenArch sh))
 genSomeParameter =
   HG.choice
   [
-    Some <$> genRegParameter
+    Some <$> genBoxParameter
     -- , Some <$> genNatParameter  -- not supported for formula printing
     -- , Some <$> genIntParameter  -- not supported for formula printing
   ]
@@ -375,6 +375,11 @@ genBV32SymExpr sym params opvars litvars = do
     -- , HG.subtermM
     --   (genBV32SymExpr sym params opvars litvars)
     --   (liftIO . WI.bvCountTrailingZeros sym)
+
+    -- TODO: bvZext, bvSext, bvTrunc operations
+    -- TODO: comparators: bvIsNonzero, bvUle, bvEq, bvNe, bvIsNeg, testBitBV, etc.
+    -- TODO: branching: bvIte
+
 
     -- , (liftIO . WI.bvNeg sym) =<< genBV32SymExpr sym
     ]

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -137,8 +137,10 @@ genSolverSymbol = HG.choice [ -- return WI.emptySymbol  -- KWQ: generates eqns w
                              genUserSymbol
                             -- , genSystemSymbol  -- KWQ: cannot parse the printed name with a !
                             ]
-  where genUSym = HG.string (linear 1 32) (HG.choice [ HG.alphaNum
-                                                     , return '_' ])
+  where genUSym = HG.string (linear 1 32) $
+                  HG.frequency [ (90, HG.alphaNum)
+                               , (10, return '_')
+                               ]
         genSSym s = let sp = zip3 (L.inits s) (repeat "!") (L.tails s)
                         join3 (a,b,c) = a <> b <> c
                         s' = map join3 $ tail sp

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -610,3 +610,10 @@ instance ( Monad m
          ) =>
          MkOperands (GenT m) sym (OperandPair sym) "Bar" where
   mkOperand = genBoundVar_BV32ArgBar
+
+instance ( Monad m
+         , MonadIO m
+         , WI.IsSymExprBuilder sym
+         ) =>
+         MkOperands (GenT m) sym (OperandPair sym) "Box" where
+  mkOperand = genBoundVar_BV32ArgBox

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -326,6 +326,21 @@ genBV32SymExpr sym params opvars litvars = do
       (genBV32SymExpr sym params opvars litvars)
       (\x y -> liftIO $ WI.bvXorBits sym x y)
 
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvShl sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvLshr sym x y)
+
+    , HG.subtermM2
+      (genBV32SymExpr sym params opvars litvars)
+      (genBV32SymExpr sym params opvars litvars)
+      (\x y -> liftIO $ WI.bvAshr sym x y)
+
     -- unhandled App in Printer.hs:232
     -- , HG.subtermM
     --   (genBV32SymExpr sym params opvars litvars)

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -53,6 +53,7 @@ genNat = HG.frequency [ (5, return 0)
                       ]
          -- Ensures that 0 and 1 are present in any reasonably-sized distribution
 
+
 ----------------------------------------------------------------------
 -- Location Generators
 

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -11,11 +11,9 @@
 module TestArchPropGen
 where
 
-import           Control.Monad.IO.Class
 import           Data.Int ( Int64 )
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.List as SL
-import           Data.Parameterized.Nonce ( newIONonceGenerator )
 import           Data.Parameterized.Some
 import qualified Data.Set as Set
 import           GHC.TypeLits ( Symbol )
@@ -23,12 +21,10 @@ import           Hedgehog
 import qualified Hedgehog.Gen as HG
 import           Hedgehog.Range
 import           Numeric.Natural
-import qualified SemMC.Architecture as SA
 import qualified SemMC.BoundVar as BV
 import qualified SemMC.Formula.Formula as F
 import           TestArch
 import           What4.BaseTypes
-import qualified What4.Expr.Builder as WB
 import qualified What4.Interface as WI
 
 

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -205,7 +205,12 @@ type TestBoundVar sym = BV.BoundVar sym TestGenArch
 genBoundVar_NatArgFoo :: Monad m => MonadIO m =>
                          WI.IsSymExprBuilder sym =>
                          sym -> GenT m (TestBoundVar sym "Foo")
-genBoundVar_NatArgFoo sym = BV.BoundVar <$> genBoundNatVar sym Nothing  -- KWQ: generic genBoundVar?
+genBoundVar_NatArgFoo sym = BV.BoundVar <$> genBoundNatVar sym Nothing
+
+genBoundVar_BV32ArgBar :: Monad m => MonadIO m =>
+                          WI.IsSymExprBuilder sym =>
+                          sym -> GenT m (TestBoundVar sym "Bar")
+genBoundVar_BV32ArgBar sym = BV.BoundVar <$> genBoundBV32Var sym Nothing
 
 ----------------------------------------------------------------------
 -- What4.Interface.SymExpr generators
@@ -411,3 +416,10 @@ instance ( Monad m
          ) =>
          MkOperands (GenT m) sym (TestBoundVar sym) "Foo" where
   mkOperand = genBoundVar_NatArgFoo
+
+instance ( Monad m
+         , MonadIO m
+         , WI.IsSymExprBuilder sym
+         ) =>
+         MkOperands (GenT m) sym (TestBoundVar sym) "Bar" where
+  mkOperand = genBoundVar_BV32ArgBar

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -1,22 +1,29 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
 module TestArchPropGen
 where
 
+import           Control.Monad.IO.Class ( MonadIO, liftIO )
+import qualified Data.Foldable as F
 import           Data.Int ( Int64 )
-import           Data.Parameterized.Pair ( Pair(..) )
+import qualified Data.List as L
 import           Data.Parameterized.Classes
 import           Data.Parameterized.List ( List( (:<) ) )
 import qualified Data.Parameterized.List as PL
 import qualified Data.Parameterized.Map as MapF
+import           Data.Parameterized.Pair ( Pair(..) )
 import           Data.Parameterized.Some
 import qualified Data.Set as Set
 import           GHC.TypeLits ( Symbol )
@@ -29,6 +36,7 @@ import qualified SemMC.Formula.Formula as F
 import           TestArch
 import           What4.BaseTypes
 import qualified What4.Interface as WI
+import           What4.Symbol ( systemSymbol )
 
 
 genNat :: Monad m => GenT m Natural
@@ -98,29 +106,18 @@ genSomeParameter =
 
 -- data TestSymLocation :: BaseType -> Type where
 --   TestSymLocation :: TestSymBackend
-data TestSymExpr (ty :: BaseType) = TestSymExpr
-  deriving Show
-
-instance ShowF TestSymExpr
-
-data TestBoundVar (th :: BaseType) = TestBoundVar
-  deriving Show
-
-instance ShowF TestBoundVar
-
-data TestSymbolicBackend = TestSymbolicBackend
- deriving Show
-
-type instance WI.SymExpr TestSymbolicBackend = TestSymExpr
-type instance WI.BoundVar TestSymbolicBackend = TestBoundVar
-
-type TestOperand = BV.BoundVar TestSymbolicBackend TestGenArch
 
 
 ----------------------------------------------------------------------
 -- What4.Interface.BoundVar generators
 
-  -- KWQ: proxy sym?
+{-
+data TestBoundVar (th :: BaseType) = TestBoundVar
+  deriving Show
+
+instance ShowF TestBoundVar
+type instance WI.BoundVar TestSymbolicBackend = TestBoundVar
+
 genBoundNatVar :: Monad m => GenT m (WI.BoundVar TestSymbolicBackend BaseNatType)
 genBoundNatVar = return TestBoundVar
 
@@ -129,6 +126,96 @@ genBoundIntVar = return TestBoundVar
 
 genBoundVar_NatArgFoo :: Monad m => GenT m (BV.BoundVar TestSymbolicBackend TestGenArch "NatArg:Foo")
 genBoundVar_NatArgFoo = BV.BoundVar <$> genBoundNatVar
+-}
+
+------------------------------
+
+  -- KWQ: proxy sym? pass sym?
+-- genBoundNatVar :: Monad m => sym -> GenT m (WI.BoundVar sym BaseNatType)
+-- genBoundNatVar _ = return TestBoundVar
+
+-- genBoundIntVar :: Monad m => sym -> GenT m (WI.BoundVar sym BaseIntegerType)
+-- genBoundIntVar _ = return TestBoundVar
+
+genSolverSymbol :: Monad m => GenT m WI.SolverSymbol
+genSolverSymbol = HG.choice [ -- return WI.emptySymbol  -- KWQ: generates eqns with this, but the eqns are invalid!
+                             genUserSymbol
+                            -- , genSystemSymbol  -- KWQ: cannot parse the printed name with a !
+                            ]
+  where genUSym = HG.string (linear 1 32) (HG.choice [ HG.alphaNum
+                                                     , return '_' ])
+        genSSym s = let sp = zip3 (L.inits s) (repeat "!") (L.tails s)
+                        join3 (a,b,c) = a <> b <> c
+                        s' = map join3 $ tail sp
+                    in HG.element s'
+        -- genUserSymbol = (WI.userSymbol <$> genUSym) >>= \case
+        genUserSymbol = (WI.userSymbol . (<>) "user__" <$> genUSym) >>= \case
+          -- alphaNum and _, but must not match a known Yices/smtlib keyword
+          Left _ -> genUserSymbol  -- could repeat forever...
+          Right s -> return s
+        genSystemSymbol = do s <- genUSym
+                             -- Like a userSymbol but must contain a !
+                             -- and systemSymbol throws an error if
+                             -- not happy.  Let genUSymbol+userSymbol
+                             -- eliminate keywords, and genSSym
+                             -- ensures that there is at least one !
+                             -- to prevent failure.
+                             case WI.userSymbol s of
+                               Left _ -> genSystemSymbol -- could repeat forever...
+                               -- Right _ -> systemSymbol <$> genSSym s
+                               Right _ -> systemSymbol . (<>) "sys__" <$> genSSym s
+
+----------------------------------------------------------------------
+
+genBoundNatVar :: ( Monad m
+                  , MonadIO m
+                  , WI.IsSymExprBuilder sym
+                  ) =>
+                  sym -> GenT m (WI.BoundVar sym BaseNatType)
+genBoundNatVar sym = do s <- genSolverSymbol
+                        liftIO $ WI.freshBoundVar sym s BaseNatRepr
+
+genBoundIntVar :: ( Monad m
+                  , MonadIO m
+                  , WI.IsSymExprBuilder sym
+                  ) =>
+                  sym -> GenT m (WI.BoundVar sym BaseIntegerType)
+genBoundIntVar sym = do s <- genSolverSymbol
+                        liftIO $ WI.freshBoundVar sym s BaseIntegerRepr
+
+type TestBoundVar sym = BV.BoundVar sym TestGenArch
+
+genBoundVar_NatArgFoo :: Monad m => MonadIO m =>
+                         WI.IsSymExprBuilder sym =>
+                         sym -> GenT m (TestBoundVar sym "Foo")
+genBoundVar_NatArgFoo sym = BV.BoundVar <$> genBoundNatVar sym  -- KWQ: generic genBoundVar?
+-- genBoundVar_NatArgFoo sym =
+--   do bnv <- genBoundNatVar sym  -- KWQ: generic genBoundVar?
+--      liftIO $ putStrLn
+--      return BV.BoundVar bnv
+
+----------------------------------------------------------------------
+-- What4.Interface.SymExpr generators
+
+genNatSymExpr :: ( Monad m
+                 , MonadIO m
+                 , WI.IsExprBuilder sym
+                 ) =>
+                 sym ->
+                 GenT m (WI.SymExpr sym BaseNatType)
+-- genNatSymExpr = return $ TestLitNat 3
+genNatSymExpr sym = liftIO $ -- WI.natLit sym 3
+                    do x <- WI.natLit sym 3
+                       y <- WI.natLit sym 5
+                       WI.natAdd sym x y
+  -- where sym = TestSymbolicBackend
+
+genIntSymExpr :: ( MonadIO m
+                 , WI.IsExprBuilder sym
+                 ) =>
+                 sym -> GenT m (WI.SymExpr sym BaseIntegerType)
+genIntSymExpr sym = liftIO $ WI.intLit sym 9
+  -- where sym = TestSymbolicBackend
 
 ----------------------------------------------------------------------
 -- Formula.ParameterizedFormula generators
@@ -136,23 +223,36 @@ genBoundVar_NatArgFoo = BV.BoundVar <$> genBoundNatVar
   -- KWQ: proxy sym?
 genParameterizedFormula :: forall sh sym m .  -- reordered args to allow TypeApplication of sh first
                            ( Monad m
-                           , TestSymbolicBackend ~ sym
-                           , MkOperands (GenT m) (PL.List TestOperand) sh
+                           , MonadIO m
+                           , WI.IsSymExprBuilder sym
+                           , MkOperands (GenT m) sym (PL.List (TestBoundVar sym)) sh
                            ) =>
                            sym
                         -> GenT m (F.ParameterizedFormula sym TestGenArch (sh :: [Symbol]))
-genParameterizedFormula _ = do
+genParameterizedFormula sym = do
   params <- Set.fromList <$> HG.list (linear 0 10) genSomeParameter
-  operandVars <- mkOperand
-  literalVars <- MapF.fromList <$> HG.list (linear 0 10)
-                 (HG.choice [ (Pair <$> genNatLocation <*> genBoundNatVar)
-                            , (Pair <$> genIntLocation <*> genBoundIntVar)
-                            ])
+  operandVars <- mkOperand sym
+  literalVars <- if F.length params == 0
+                 then return MapF.empty
+                 else MapF.fromList <$> HG.list (linear 0 10)
+                      (HG.choice [ (Pair <$> genNatLocation <*> genBoundNatVar sym)
+                                 , (Pair <$> genIntLocation <*> genBoundIntVar sym)
+                                 ])
+  defs <- if F.length params == 0
+          then return MapF.empty
+          else MapF.fromList <$> HG.list (linear 0 10)  -- keys should be a (sub-)Set from params
+               (do Some p <- HG.element $ F.toList params
+                   case testEquality (F.paramType p) BaseNatRepr of
+                     Just Refl -> Pair p <$> genNatSymExpr sym
+                     Nothing -> case testEquality (F.paramType p) BaseIntegerRepr of
+                                  Just Refl -> Pair p <$> genIntSymExpr sym
+                                  Nothing -> error "unsupported parameter type in generator"
+               )
   return F.ParameterizedFormula
     { F.pfUses = params
     , F.pfOperandVars = operandVars  -- PL.List (BV.BoundVar sym arch) sh
     , F.pfLiteralVars = literalVars  -- MapF.MapF (L.Location arch) (WI.BoundVar sym)
-    , F.pfDefs = undefined
+    , F.pfDefs = defs  -- MapF.MapF (Parameter arch sh) (WI.SymExpr sym)
     }
 
 
@@ -160,16 +260,24 @@ genParameterizedFormula _ = do
 -- Helpers to generate the operandVars based on the caller-specified
 -- ParameterizedFormula 'sh'
 
-class Monad m => MkOperands m (f :: k -> *) (ctx :: k) where
-  mkOperand :: m (f ctx)
+class Monad m => MkOperands m sym (f :: k -> *) (ctx :: k) where
+  mkOperand :: sym -> m (f ctx)
 
-instance (Monad m) => MkOperands m (PL.List TestOperand) '[] where
-  mkOperand = return PL.Nil
-instance (Monad m, MkOperands m TestOperand o, MkOperands m (PL.List TestOperand) os) =>
-  MkOperands m (PL.List TestOperand) (o ': os) where
-  mkOperand = do opl <- mkOperand
-                 opr <- mkOperand
-                 return $ opl :< opr
+instance Monad m => MkOperands m sym (PL.List (TestBoundVar sym)) '[] where
+  mkOperand _ = return PL.Nil
 
-instance (Monad m) => MkOperands (GenT m) TestOperand "NatArg:Foo" where
+instance ( Monad m
+         , MkOperands m sym (TestBoundVar sym) o
+         , MkOperands m sym (PL.List (TestBoundVar sym)) os
+         ) =>
+         MkOperands m sym (PL.List (TestBoundVar sym)) (o ': os) where
+  mkOperand sym = do opl <- mkOperand sym
+                     opr <- mkOperand sym
+                     return $ opl :< opr
+
+instance ( Monad m
+         , MonadIO m
+         , WI.IsSymExprBuilder sym
+         ) =>
+         MkOperands (GenT m) sym (TestBoundVar sym) "Foo" where
   mkOperand = genBoundVar_NatArgFoo

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -53,25 +53,21 @@ genNatParameter = HG.choice
                     -- -> Parameter arch sh tp
                   ]
 
--- instance Arbitrary (F.Parameter TestGenArch sh BaseNatType) where
---   arbitrary = oneof [ undefined -- return $ F.OperandParameter oprepr1 undefined
---                     , F.LiteralParameter <$> arbitrary
---                     -- , return $ F.FunctionParameter undefined undefined oprepr2
---                     ]
---               where oprepr1 = undefined
---                     oprepr2 = undefined
---                     -- loc :: TestLocation ty
---                     -- loc = arbitrary
+genIntParameter :: Monad m => GenT m (F.Parameter TestGenArch sh BaseIntegerType)
+genIntParameter = HG.choice
+                  [
+                    -- , F.OperandParameter :: BaseTypeRepr (A.OperandType arch s) -> SL.Index sh s -> Parameter arch sh (A.OperandType arch s)
+                    F.LiteralParameter <$> genIntLocation
+                    -- , FunctionParameter :: String
+                    -- -- The name of the uninterpreted function
+                    -- -> WrappedOperand arch sh s
+                    -- -- The operand we are calling the function on (this is a newtype so
+                    -- -- we don't need an extra typerepr)
+                    -- -> BaseTypeRepr tp
+                    -- -- The typerepr for the return type of the function
+                    -- -> Parameter arch sh tp
+                  ]
 
--- instance Arbitrary (F.Parameter TestGenArch sh BaseIntegerType) where
---   arbitrary = oneof [ undefined -- return $ F.OperandParameter oprepr1 undefined
---                     , F.LiteralParameter <$> arbitrary
---                     -- , return $ F.FunctionParameter undefined undefined oprepr2
---                     ]
---               where oprepr1 = undefined
---                     oprepr2 = undefined
---                     -- loc :: TestLocation ty
---                     -- loc = arbitrary
 
 ----------------------------------------------------------------------
 -- Formula.ParameterizedFormula generators

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -69,7 +69,7 @@ genIntLocation = TestIntLoc <$>
                  -- Ensures that 0 and 1 are present in any reasonably-sized distribution
 
 genRegLocation :: Monad m => GenT m (TestLocation (BaseBVType 32))
-genRegLocation = TestRegLoc <$> HG.element [0..3]
+genRegLocation = TestBoxLoc <$> HG.element [0..3]
 
 ----------------------------------------------------------------------
 -- Function.Parameter Generators

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -32,8 +32,8 @@ import           Prelude
 
 
 debugPrint, alwaysPrint :: MonadIO m => String -> m ()
-debugPrint = alwaysPrint
--- debugPrint _ = return ()
+-- debugPrint = alwaysPrint
+debugPrint _ = return ()
 alwaysPrint = liftIO . putStrLn
 
 

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -131,10 +131,9 @@ compareParameterizedFormulasSymbolically sym operands ncycles origFormula result
      on (===) (MapF.keys . SF.pfDefs) origFormula resultFormula
      (_te1, f1) <- liftIO $ instantiateFormula sym origFormula operands
      (_te2, f2) <- liftIO $ instantiateFormula sym resultFormula operands
-     liftIO $ putStrLn "checkin' equiv..."
      equiv <- liftIO $ formulasEquivSym sym f1 f2
      case equiv of
-       Equivalent -> liftIO (putStrLn "boo yah!") >> success
+       Equivalent -> success
        DifferentBehavior _ -> failure
        Timeout -> failure
 

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -58,7 +58,6 @@ compareParameterizedFormulasSimply
   :: ( MonadIO m
      , MonadTest m
      , TestEquality (SA.Location arch)
-     , Eq (WI.BoundVar sym (SA.OperandType arch op))
      , ShowF (SA.Location arch)
      , ShowF (WI.BoundVar sym)
      , WI.BoundVar sym ~ WE.ExprBoundVar t
@@ -66,8 +65,8 @@ compareParameterizedFormulasSimply
      ) =>
      sym
   -> Integer
-  -> SF.ParameterizedFormula sym arch (op : r)
-  -> SF.ParameterizedFormula sym arch (op : r)
+  -> SF.ParameterizedFormula sym arch sh
+  -> SF.ParameterizedFormula sym arch sh
   -> m ()
 compareParameterizedFormulasSimply sym ncycles origFormula resultFormula =
   do on (===) SF.pfUses origFormula resultFormula
@@ -101,7 +100,6 @@ compareParameterizedFormulasSymbolically
   :: ( MonadIO m
      , MonadTest m
      , TestEquality (SA.Location arch)
-     , Eq (WI.BoundVar sym (SA.OperandType arch op))
      , ShowF (SA.Location arch)
      , ShowF (WI.BoundVar sym)
      , WI.BoundVar sym ~ WE.ExprBoundVar t
@@ -111,10 +109,10 @@ compareParameterizedFormulasSymbolically
      , WPO.OnlineSolver t solver
      ) =>
      sym
-  -> PL.List (SA.Operand arch) (op : r)
+  -> PL.List (SA.Operand arch) sh
   -> Integer
-  -> SF.ParameterizedFormula sym arch (op : r)
-  -> SF.ParameterizedFormula sym arch (op : r)
+  -> SF.ParameterizedFormula sym arch sh
+  -> SF.ParameterizedFormula sym arch sh
   -> m ()
 compareParameterizedFormulasSymbolically sym operands ncycles origFormula resultFormula =
   do on (===) SF.pfUses origFormula resultFormula
@@ -155,14 +153,13 @@ compareParameterizedFormulasSymbolically sym operands ncycles origFormula result
 -- each time it reads a pfOperandVar).
 compareOperandLists :: ( MonadIO m
                        , MonadTest m
-                       , Eq (WI.BoundVar sym (SA.OperandType arch op))
                        , ShowF (WI.BoundVar sym)
                        , WI.BoundVar sym ~ WE.ExprBoundVar t
                        ) =>
                        sym
                     -> Integer
-                    -> PL.List (BV.BoundVar sym arch) (op : r)
-                    -> PL.List (BV.BoundVar sym arch) (op : r)
+                    -> PL.List (BV.BoundVar sym arch) sh
+                    -> PL.List (BV.BoundVar sym arch) sh
                     -> m ()
 compareOperandLists sym ncycle origOprnds resultOprnds = do
   on (===) lengthFC origOprnds resultOprnds

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -139,10 +139,10 @@ compareBVars :: ( MonadIO m
              -> WI.BoundVar sym ty
              -> m ()
 compareBVars mbPrefix _ ncycles origOprnd resultOprnd = do
-  debugPrint $ "bvId=" <> show (WE.bvarId origOprnd)
-  debugPrint $ "bvLoc=" <> show (WE.bvarLoc origOprnd)
-  debugPrint $ "bvName=" <> show (WE.bvarName origOprnd)
-  debugPrint $ "bvType=" <> show (WE.bvarType origOprnd)
+  -- debugPrint $ "bvId=" <> show (WE.bvarId origOprnd)
+  -- debugPrint $ "bvLoc=" <> show (WE.bvarLoc origOprnd)
+  -- debugPrint $ "bvName=" <> show (WE.bvarName origOprnd)
+  -- debugPrint $ "bvType=" <> show (WE.bvarType origOprnd)
   -- If the resultOprnd is supplied via a Formula Parse, the Parse
   -- operation will add an 'operandVarPrefix' (e.g. "op_") prefix to
   -- the parsed names to indicate they occurred in the operand

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -13,7 +13,7 @@ import           Data.Function ( on )
 import qualified Data.List as L
 import           Data.Parameterized.Classes
 import           Data.Parameterized.List ( List( (:<) ) )
-import qualified Data.Parameterized.List as SL
+import qualified Data.Parameterized.List as PL
 import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.Some
 import           Data.Parameterized.TraversableFC
@@ -97,14 +97,14 @@ compareOperandLists :: ( MonadIO m
                        ) =>
                        sym
                     -> Integer
-                    -> SL.List (BV.BoundVar sym arch) (op : r)
-                    -> SL.List (BV.BoundVar sym arch) (op : r)
+                    -> PL.List (BV.BoundVar sym arch) (op : r)
+                    -> PL.List (BV.BoundVar sym arch) (op : r)
                     -> m ()
 compareOperandLists sym ncycle origOprnds resultOprnds = do
   on (===) lengthFC origOprnds resultOprnds
   compareEachOperand sym ncycle origOprnds resultOprnds
 
--- | Iterates through the SL.List elements pairwise, comparing each
+-- | Iterates through the PL.List elements pairwise, comparing each
 -- pair of elements for "equality".
 compareEachOperand :: ( MonadIO m
                       , MonadTest m
@@ -112,10 +112,10 @@ compareEachOperand :: ( MonadIO m
                       ) =>
                       sym
                    -> Integer
-                   -> SL.List (BV.BoundVar sym arch) sh
-                   -> SL.List (BV.BoundVar sym arch) sh
+                   -> PL.List (BV.BoundVar sym arch) sh
+                   -> PL.List (BV.BoundVar sym arch) sh
                    -> m ()
-compareEachOperand _ _ SL.Nil SL.Nil = return ()
+compareEachOperand _ _ PL.Nil PL.Nil = return ()
 compareEachOperand sym ncycle (l :< ls) (r :< rs) = do
   compareOperands sym ncycle l r
   compareEachOperand sym ncycle ls rs

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -7,28 +7,37 @@
 
 module TestUtils where
 
-import           Control.Monad.IO.Class ( MonadIO )
+import           Control.Monad ( forM_ )
+import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import           Data.Function ( on )
 import qualified Data.List as L
 import           Data.Parameterized.Classes
 import           Data.Parameterized.List ( List( (:<) ) )
 import qualified Data.Parameterized.List as SL
+import qualified Data.Parameterized.Map as MapF
+import           Data.Parameterized.Some
 import           Data.Parameterized.TraversableFC
 import           GHC.TypeLits ( Symbol )
 import           Hedgehog
 import qualified SemMC.Architecture as SA
 import qualified SemMC.BoundVar as BV
-import           SemMC.Formula.Parser ( operandVarPrefix )
+import           SemMC.Formula.Parser ( literalVarPrefix
+                                      , operandVarPrefix )
+import           TestArch
 import qualified What4.Expr.Builder as WE
 import qualified What4.Interface as WI
 
 import           Prelude
 
 
-debugPrint :: Monad m => msg -> m ()
--- debugPrint = liftIO $ putStrLn  -- add liftIO to Control.Monad.IO.Class import
-debugPrint _ = return ()
+debugPrint, alwaysPrint :: MonadIO m => String -> m ()
+debugPrint = alwaysPrint
+-- debugPrint _ = return ()
+alwaysPrint = liftIO . putStrLn
 
+
+----------------------------------------------------------------------
+-- Operands
 
 -- | Compare two Parameterized Lists of Operands.  The expectation is
 -- that these are similar and the comparison is the input to and
@@ -48,13 +57,14 @@ compareOperandLists :: ( MonadIO m
                        , ShowF (WI.BoundVar sym)
                        , WI.BoundVar sym ~ WE.ExprBoundVar t
                        ) =>
-                       Integer
+                       sym
+                    -> Integer
                     -> SL.List (BV.BoundVar sym arch) (op : r)
                     -> SL.List (BV.BoundVar sym arch) (op : r)
                     -> m ()
-compareOperandLists ncycle origOprnds resultOprnds = do
+compareOperandLists sym ncycle origOprnds resultOprnds = do
   on (===) lengthFC origOprnds resultOprnds
-  compareEachOperand ncycle origOprnds resultOprnds
+  compareEachOperand sym ncycle origOprnds resultOprnds
 
 -- | Iterates through the SL.List elements pairwise, comparing each
 -- pair of elements for "equality".
@@ -62,14 +72,15 @@ compareEachOperand :: ( MonadIO m
                       , MonadTest m
                       , WI.BoundVar sym ~ WE.ExprBoundVar t
                       ) =>
-                      Integer
+                      sym
+                   -> Integer
                    -> SL.List (BV.BoundVar sym arch) sh
                    -> SL.List (BV.BoundVar sym arch) sh
                    -> m ()
-compareEachOperand _ SL.Nil SL.Nil = return ()
-compareEachOperand ncycle (l :< ls) (r :< rs) = do
-  compareOperands ncycle l r
-  compareEachOperand ncycle ls rs
+compareEachOperand _ _ SL.Nil SL.Nil = return ()
+compareEachOperand sym ncycle (l :< ls) (r :< rs) = do
+  compareOperands sym ncycle l r
+  compareEachOperand sym ncycle ls rs
 
 
 -- | Compares a specific Operand to an Operand that is expected to be
@@ -89,39 +100,101 @@ compareOperands :: ( MonadIO m
                    , ShowF (WI.BoundVar sym)
                    , WI.BoundVar sym ~ WE.ExprBoundVar t
                    ) =>
-                   Integer
+                   sym
+                -> Integer
                 -> BV.BoundVar sym arch (op :: Symbol)
                 -> BV.BoundVar sym arch (op :: Symbol)
                 -> m ()
-compareOperands ncycles origOprnd resultOprnd = do
-  debugPrint $ "bvId=" <> show (WE.bvarId $ BV.unBoundVar origOprnd)
-  debugPrint $ "bvLoc=" <> show (WE.bvarLoc $ BV.unBoundVar origOprnd)
-  debugPrint $ "bvName=" <> show (WE.bvarName $ BV.unBoundVar origOprnd)
-  debugPrint $ "bvType=" <> show (WE.bvarType $ BV.unBoundVar origOprnd)
+compareOperands = compareSemMCBVars (Just operandVarPrefix)
+
+
+----------------------------------------------------------------------
+-- BoundVars
+
+compareSemMCBVars :: ( MonadIO m
+                     , MonadTest m
+                     , Eq (WI.BoundVar sym (SA.OperandType arch op))
+                     , ShowF (WI.BoundVar sym)
+                     , WI.BoundVar sym ~ WE.ExprBoundVar t
+                     ) =>
+                     Maybe String
+                  -> sym
+                  -> Integer
+                  -> BV.BoundVar sym arch (op :: Symbol)
+                  -> BV.BoundVar sym arch (op :: Symbol)
+                  -> m ()
+compareSemMCBVars mbPrefix sym ncycles origOprnd resultOprnd =
+  compareBVars mbPrefix sym ncycles
+  (BV.unBoundVar origOprnd)
+  (BV.unBoundVar resultOprnd)
+
+compareBVars :: ( MonadIO m
+                , MonadTest m
+                , WI.BoundVar sym ~ WE.ExprBoundVar t
+                ) =>
+                Maybe String
+             -> sym
+             -> Integer
+             -> WI.BoundVar sym ty
+             -> WI.BoundVar sym ty
+             -> m ()
+compareBVars mbPrefix _ ncycles origOprnd resultOprnd = do
+  debugPrint $ "bvId=" <> show (WE.bvarId origOprnd)
+  debugPrint $ "bvLoc=" <> show (WE.bvarLoc origOprnd)
+  debugPrint $ "bvName=" <> show (WE.bvarName origOprnd)
+  debugPrint $ "bvType=" <> show (WE.bvarType origOprnd)
   -- If the resultOprnd is supplied via a Formula Parse, the Parse
   -- operation will add an 'operandVarPrefix' (e.g. "op_") prefix to
   -- the parsed names to indicate they occurred in the operand
   -- location.  Allow that here if it is present.
   let orignm = bvName origOprnd
       rsltnm = bvName resultOprnd
-      bvName = WE.bvarName . BV.unBoundVar
+      bvName = WE.bvarName
       rsltnm_str = show rsltnm
-      newnm = WI.userSymbol $ dropPfx ncycles operandVarPrefix rsltnm_str
-      dropPfx n p s = if n == 0 then s
-                      else let s' = if p `L.isPrefixOf` s
-                                    then drop (length p) s
-                                    else s
-                           in dropPfx (n-1) p s'
+      newnm = WI.userSymbol $ dropPfx ncycles mbPrefix rsltnm_str
+      dropPfx _ Nothing s = s
+      dropPfx 0 _ s = s
+      dropPfx n (Just p) s = let s' = if p `L.isPrefixOf` s
+                                      then drop (length p) s
+                                      else s
+                             in dropPfx (n-1) mbPrefix s'
   if (orignm == rsltnm)
     then orignm === rsltnm
     else do nm' <- evalEither newnm
             orignm === nm'
-  on compareBaseTypes (WE.bvarType . BV.unBoundVar) origOprnd resultOprnd
+  on compareBaseTypes WE.bvarType origOprnd resultOprnd
   -- cannot compare bvarId: generated via Nonce
   -- cannot compare bvarKind: not exported from What4.Expr.Builder
   -- cannot compare bvarLoc: dependent on sym state
   success
 
+
+----------------------------------------------------------------------
+-- LiteralVars
+
+compareLiteralVarMaps :: ( MonadIO m
+                         , MonadTest m
+                         , WI.BoundVar sym ~ WE.ExprBoundVar t
+                         ) =>
+                         sym
+                      -> MapF.MapF TestLocation (WI.BoundVar sym)
+                      -> MapF.MapF TestLocation (WI.BoundVar sym)
+                      -> m ()
+compareLiteralVarMaps sym origMap resultMap = do
+  MapF.size origMap === MapF.size resultMap
+  MapF.keys origMap === MapF.keys resultMap
+  forM_ (MapF.keys origMap) $ \(Some k) -> do
+    let origBV = MapF.lookup k origMap
+        resultBV = MapF.lookup k resultMap
+    assert $ isJust origBV
+    assert $ isJust resultBV
+    let Just o = origBV
+        Just r = resultBV
+    compareBVars (Just literalVarPrefix) sym 1 o r
+
+
+----------------------------------------------------------------------
+-- BaseTypes
 
 -- | Verifies that two BaseTypes are equal
 compareBaseTypes :: ( MonadIO m

--- a/semmc/tests/semstore/TestUtils.hs
+++ b/semmc/tests/semstore/TestUtils.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TestUtils where
+
+import           Control.Monad.IO.Class ( MonadIO )
+import           Data.Function ( on )
+import qualified Data.List as L
+import           Data.Parameterized.Classes
+import           Data.Parameterized.List ( List( (:<) ) )
+import qualified Data.Parameterized.List as SL
+import           Data.Parameterized.TraversableFC
+import           GHC.TypeLits ( Symbol )
+import           Hedgehog
+import qualified SemMC.Architecture as SA
+import qualified SemMC.BoundVar as BV
+import           SemMC.Formula.Parser ( operandVarPrefix )
+import qualified What4.Expr.Builder as WE
+import qualified What4.Interface as WI
+
+import           Prelude
+
+
+debugPrint :: Monad m => msg -> m ()
+-- debugPrint = liftIO $ putStrLn  -- add liftIO to Control.Monad.IO.Class import
+debugPrint _ = return ()
+
+
+-- | Compare two Parameterized Lists of Operands.  The expectation is
+-- that these are similar and the comparison is the input to and
+-- results from (for example) a round-trip serialization.  Since it's
+-- explicitly not possible to compare different Nonce environments,
+-- the same Nonce must be used for all operations and thus the
+-- comparison is permissive on items like the nonce-ID based on the
+-- above expectation.
+--
+-- The ncycle argument is the number of cycles that have been
+-- performed.  This is needed in case each cycle performs a measured
+-- modification to the Formula (e.g. the Formula Parser adds "op_"
+-- each time it reads a pfOperandVar).
+compareOperandLists :: ( MonadIO m
+                       , MonadTest m
+                       , Eq (WI.BoundVar sym (SA.OperandType arch op))
+                       , ShowF (WI.BoundVar sym)
+                       , WI.BoundVar sym ~ WE.ExprBoundVar t
+                       ) =>
+                       Integer
+                    -> SL.List (BV.BoundVar sym arch) (op : r)
+                    -> SL.List (BV.BoundVar sym arch) (op : r)
+                    -> m ()
+compareOperandLists ncycle origOprnds resultOprnds = do
+  on (===) lengthFC origOprnds resultOprnds
+  compareEachOperand ncycle origOprnds resultOprnds
+
+-- | Iterates through the SL.List elements pairwise, comparing each
+-- pair of elements for "equality".
+compareEachOperand :: ( MonadIO m
+                      , MonadTest m
+                      , WI.BoundVar sym ~ WE.ExprBoundVar t
+                      ) =>
+                      Integer
+                   -> SL.List (BV.BoundVar sym arch) sh
+                   -> SL.List (BV.BoundVar sym arch) sh
+                   -> m ()
+compareEachOperand _ SL.Nil SL.Nil = return ()
+compareEachOperand ncycle (l :< ls) (r :< rs) = do
+  compareOperands ncycle l r
+  compareEachOperand ncycle ls rs
+
+
+-- | Compares a specific Operand to an Operand that is expected to be
+-- "equivalent" to the original.  As noted above, the equivalence may
+-- be relative a round-trip of serialization/deserialization, so some
+-- aspects (e.g. Nonce and program location) are ignored by this
+-- comparison.
+--
+-- A raw comparison without accomodation for the above expectation
+-- would yield something like:
+--
+--    Failure: ?op_user__a@4:n != ?op_op_user__a@5:n
+--
+compareOperands :: ( MonadIO m
+                   , MonadTest m
+                   , Eq (WI.BoundVar sym (SA.OperandType arch op))
+                   , ShowF (WI.BoundVar sym)
+                   , WI.BoundVar sym ~ WE.ExprBoundVar t
+                   ) =>
+                   Integer
+                -> BV.BoundVar sym arch (op :: Symbol)
+                -> BV.BoundVar sym arch (op :: Symbol)
+                -> m ()
+compareOperands ncycles origOprnd resultOprnd = do
+  debugPrint $ "bvId=" <> show (WE.bvarId $ BV.unBoundVar origOprnd)
+  debugPrint $ "bvLoc=" <> show (WE.bvarLoc $ BV.unBoundVar origOprnd)
+  debugPrint $ "bvName=" <> show (WE.bvarName $ BV.unBoundVar origOprnd)
+  debugPrint $ "bvType=" <> show (WE.bvarType $ BV.unBoundVar origOprnd)
+  -- If the resultOprnd is supplied via a Formula Parse, the Parse
+  -- operation will add an 'operandVarPrefix' (e.g. "op_") prefix to
+  -- the parsed names to indicate they occurred in the operand
+  -- location.  Allow that here if it is present.
+  let orignm = bvName origOprnd
+      rsltnm = bvName resultOprnd
+      bvName = WE.bvarName . BV.unBoundVar
+      rsltnm_str = show rsltnm
+      newnm = WI.userSymbol $ dropPfx ncycles operandVarPrefix rsltnm_str
+      dropPfx n p s = if n == 0 then s
+                      else let s' = if p `L.isPrefixOf` s
+                                    then drop (length p) s
+                                    else s
+                           in dropPfx (n-1) p s'
+  if (orignm == rsltnm)
+    then orignm === rsltnm
+    else do nm' <- evalEither newnm
+            orignm === nm'
+  on compareBaseTypes (WE.bvarType . BV.unBoundVar) origOprnd resultOprnd
+  -- cannot compare bvarId: generated via Nonce
+  -- cannot compare bvarKind: not exported from What4.Expr.Builder
+  -- cannot compare bvarLoc: dependent on sym state
+  success
+
+
+-- | Verifies that two BaseTypes are equal
+compareBaseTypes :: ( MonadIO m
+                    , MonadTest m
+                    ) =>
+                    WI.BaseTypeRepr t1 -> WI.BaseTypeRepr t2 -> m ()
+compareBaseTypes ty1 ty2 =
+  case testEquality ty1 ty2 of
+    Just Refl -> success
+    Nothing -> show ty1 === show ty2 -- fails, but reveals types


### PR DESCRIPTION
Adds a framework for creating a Test Architecture with associated ParameterizedFormulas that are serialized to S-expression storage forms and then re-loaded and parsed to check for round-trip formula equivalence.

This is a minimal implementation with lots more that could be added, but its a (good?) start.