### PR TITLE
bug: fix SemMC.DSL bool serialization and related artifacts

### DIFF
--- a/semmc-arm/data/sem/STR_POST_IMM.sem
+++ b/semmc-arm/data/sem/STR_POST_IMM.sem
@@ -18,9 +18,7 @@
     (with
      ()
      (let
-      ((true
-       (bveq #b0 #b0))
-       (wback true)
+      ((wback #true)
        (offAddr
         (ite
          (call uf.a32.am2offset_imm_add op.imm)

--- a/semmc-arm/data/sem/STR_PRE_IMM.sem
+++ b/semmc-arm/data/sem/STR_PRE_IMM.sem
@@ -18,9 +18,7 @@
     (with
      ()
      (let
-      ((true
-       (bveq #b0 #b0))
-       (wback true)
+      ((wback #true)
        (offAddr
         (ite
          (call uf.a32.imm12_add op.imm)

--- a/semmc-arm/data/sem/STRi12.sem
+++ b/semmc-arm/data/sem/STRi12.sem
@@ -17,9 +17,7 @@
     (with
      ()
      (let
-      ((false
-       (bveq #b0 #b0))
-       (wback false)
+      ((wback #false)
        (offAddr
         (ite
          (call uf.a32.imm12_add op.imm12)

--- a/semmc-arm/data/sem/testCondition.fun
+++ b/semmc-arm/data/sem/testCondition.fun
@@ -9,87 +9,85 @@
   (with
    ()
    (let
-    ((true
-     (bveq #b0 #b0))
-     (conditionMatch
+    ((conditionMatch
+     (ite
+      (bveq
+       ((_ extract 2 0)
+        op.instrPred)
+       #b000)
+      (bveq
+       #b1
+       ((_ extract 1 1)
+        op.cpsr))
       (ite
        (bveq
         ((_ extract 2 0)
          op.instrPred)
-        #b000)
+        #b001)
        (bveq
         #b1
-        ((_ extract 1 1)
+        ((_ extract 2 2)
          op.cpsr))
        (ite
         (bveq
          ((_ extract 2 0)
           op.instrPred)
-         #b001)
+         #b010)
         (bveq
          #b1
-         ((_ extract 2 2)
+         ((_ extract 0 0)
           op.cpsr))
         (ite
          (bveq
           ((_ extract 2 0)
            op.instrPred)
-          #b010)
+          #b011)
          (bveq
           #b1
-          ((_ extract 0 0)
+          ((_ extract 3 3)
            op.cpsr))
          (ite
           (bveq
            ((_ extract 2 0)
             op.instrPred)
-           #b011)
-          (bveq
-           #b1
-           ((_ extract 3 3)
-            op.cpsr))
+           #b100)
+          (andp
+           (bveq
+            #b1
+            ((_ extract 2 2)
+             op.cpsr))
+           (notp
+            (bveq
+             #b1
+             ((_ extract 1 1)
+              op.cpsr))))
           (ite
            (bveq
             ((_ extract 2 0)
              op.instrPred)
-            #b100)
-           (andp
-            (bveq
-             #b1
-             ((_ extract 2 2)
-              op.cpsr))
-            (notp
-             (bveq
-              #b1
-              ((_ extract 1 1)
-               op.cpsr))))
+            #b101)
+           (bveq
+            ((_ extract 0 0)
+             op.cpsr)
+            ((_ extract 3 3)
+             op.cpsr))
            (ite
             (bveq
              ((_ extract 2 0)
               op.instrPred)
-             #b101)
-            (bveq
-             ((_ extract 0 0)
-              op.cpsr)
-             ((_ extract 3 3)
-              op.cpsr))
-            (ite
+             #b110)
+            (andp
              (bveq
-              ((_ extract 2 0)
-               op.instrPred)
-              #b110)
-             (andp
+              ((_ extract 0 0)
+               op.cpsr)
+              ((_ extract 3 3)
+               op.cpsr))
+             (notp
               (bveq
-               ((_ extract 0 0)
-                op.cpsr)
-               ((_ extract 3 3)
-                op.cpsr))
-              (notp
-               (bveq
-                #b1
-                ((_ extract 1 1)
-                 op.cpsr))))
-             true)))))))))
+               #b1
+               ((_ extract 1 1)
+                op.cpsr))))
+            #true)))))))))
     (ite
      (andp
       (bveq

--- a/semmc-ppc/data/32/base/ADD4Oo.sem
+++ b/semmc-ppc/data/32/base/ADD4Oo.sem
@@ -9,127 +9,121 @@
   ((loc.CR
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (call
-      df.cmpImm
-      (bvslt
-       (bvadd op.rA op.rB)
-       #x00000000)
-      (bvsgt
-       (bvadd op.rA op.rB)
-       #x00000000)
-      #b000
-      (concat
-       (bvor
-        ((_ extract 31 31)
-         loc.XER)
+    (call
+     df.cmpImm
+     (bvslt
+      (bvadd op.rA op.rB)
+      #x00000000)
+     (bvsgt
+      (bvadd op.rA op.rB)
+      #x00000000)
+     #b000
+     (concat
+      (bvor
+       ((_ extract 31 31)
+        loc.XER)
+       (ite
         (ite
+         (andp
+          (bvslt op.rA #x00000000)
+          (bvslt op.rB #x00000000))
+         (notp
+          (bvslt
+           (bvadd op.rA op.rB)
+           #x00000000))
          (ite
           (andp
-           (bvslt op.rA #x00000000)
-           (bvslt op.rB #x00000000))
+           (bvsge op.rA #x00000000)
+           (bvsge op.rB #x00000000))
           (notp
-           (bvslt
+           (bvsge
             (bvadd op.rA op.rB)
             #x00000000))
+          #false))
+        #b1
+        #b0))
+      ((_ extract 30 0)
+       (concat
+        ((_ extract 31 31)
+         loc.XER)
+        (concat
+         (ite
           (ite
            (andp
-            (bvsge op.rA #x00000000)
-            (bvsge op.rB #x00000000))
+            (bvslt op.rA #x00000000)
+            (bvslt op.rB #x00000000))
            (notp
-            (bvsge
+            (bvslt
              (bvadd op.rA op.rB)
              #x00000000))
-           false))
-         #b1
-         #b0))
-       ((_ extract 30 0)
-        (concat
-         ((_ extract 31 31)
-          loc.XER)
-         (concat
-          (ite
            (ite
             (andp
-             (bvslt op.rA #x00000000)
-             (bvslt op.rB #x00000000))
+             (bvsge op.rA #x00000000)
+             (bvsge op.rB #x00000000))
             (notp
-             (bvslt
+             (bvsge
               (bvadd op.rA op.rB)
               #x00000000))
-            (ite
-             (andp
-              (bvsge op.rA #x00000000)
-              (bvsge op.rB #x00000000))
-             (notp
-              (bvsge
-               (bvadd op.rA op.rB)
-               #x00000000))
-             false))
-           #b1
-           #b0)
-          ((_ extract 29 0)
-           loc.XER)))))
-      loc.CR))))
+            #false))
+          #b1
+          #b0)
+         ((_ extract 29 0)
+          loc.XER)))))
+     loc.CR)))
    (loc.XER
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (concat
-       (bvor
-        ((_ extract 31 31)
-         loc.XER)
+     (concat
+      (bvor
+       ((_ extract 31 31)
+        loc.XER)
+       (ite
         (ite
+         (andp
+          (bvslt op.rA #x00000000)
+          (bvslt op.rB #x00000000))
+         (notp
+          (bvslt
+           (bvadd op.rA op.rB)
+           #x00000000))
          (ite
           (andp
-           (bvslt op.rA #x00000000)
-           (bvslt op.rB #x00000000))
+           (bvsge op.rA #x00000000)
+           (bvsge op.rB #x00000000))
           (notp
-           (bvslt
+           (bvsge
             (bvadd op.rA op.rB)
             #x00000000))
+          #false))
+        #b1
+        #b0))
+      ((_ extract 30 0)
+       (concat
+        ((_ extract 31 31)
+         loc.XER)
+        (concat
+         (ite
           (ite
            (andp
-            (bvsge op.rA #x00000000)
-            (bvsge op.rB #x00000000))
+            (bvslt op.rA #x00000000)
+            (bvslt op.rB #x00000000))
            (notp
-            (bvsge
+            (bvslt
              (bvadd op.rA op.rB)
              #x00000000))
-           false))
-         #b1
-         #b0))
-       ((_ extract 30 0)
-        (concat
-         ((_ extract 31 31)
-          loc.XER)
-         (concat
-          (ite
            (ite
             (andp
-             (bvslt op.rA #x00000000)
-             (bvslt op.rB #x00000000))
+             (bvsge op.rA #x00000000)
+             (bvsge op.rB #x00000000))
             (notp
-             (bvslt
+             (bvsge
               (bvadd op.rA op.rB)
               #x00000000))
-            (ite
-             (andp
-              (bvsge op.rA #x00000000)
-              (bvsge op.rB #x00000000))
-             (notp
-              (bvsge
-               (bvadd op.rA op.rB)
-               #x00000000))
-             false))
-           #b1
-           #b0)
-          ((_ extract 29 0)
-           loc.XER))))))))
+            #false))
+          #b1
+          #b0)
+         ((_ extract 29 0)
+          loc.XER)))))))
    (op.rT
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZ.sem
+++ b/semmc-ppc/data/32/manual/BDNZ.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       false)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZL.sem
+++ b/semmc-ppc/data/32/manual/BDNZL.sem
@@ -10,21 +10,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        false)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZLm.sem
+++ b/semmc-ppc/data/32/manual/BDNZLm.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        false)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZLp.sem
+++ b/semmc-ppc/data/32/manual/BDNZLp.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        false)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZm.sem
+++ b/semmc-ppc/data/32/manual/BDNZm.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       false)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDNZp.sem
+++ b/semmc-ppc/data/32/manual/BDNZp.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       false)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZ.sem
+++ b/semmc-ppc/data/32/manual/BDZ.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       true)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZL.sem
+++ b/semmc-ppc/data/32/manual/BDZL.sem
@@ -10,21 +10,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        true)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZLm.sem
+++ b/semmc-ppc/data/32/manual/BDZLm.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        true)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZLp.sem
+++ b/semmc-ppc/data/32/manual/BDZLp.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x00000001)
-          #x00000000))
-        true)
-       (bvadd
-        ((_ sign_extend 16)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x00000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x00000001)
+         #x00000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 16)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZm.sem
+++ b/semmc-ppc/data/32/manual/BDZm.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       true)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/BDZp.sem
+++ b/semmc-ppc/data/32/manual/BDZp.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x00000001)
-         #x00000000))
-       true)
-      (bvadd
-       ((_ sign_extend 16)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x00000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x00000001)
+        #x00000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 16)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x00000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/32/manual/generic_cond_ok.fun
+++ b/semmc-ppc/data/32/manual/generic_cond_ok.fun
@@ -10,32 +10,29 @@
  (body
   (with
    ()
-   (let
-    ((true
-     (bveq #b0 #b0)))
+   (ite
+    (bveq
+     #b1
+     ((_ extract 0 0)
+      (bvlshr op.bo #b00100)))
+    #true
     (ite
      (bveq
       #b1
       ((_ extract 0 0)
-       (bvlshr op.bo #b00100)))
-     true
-     (ite
-      (bveq
-       #b1
-       ((_ extract 0 0)
-        (bvlshr op.bo #b00011)))
+       (bvlshr op.bo #b00011)))
+     (bveq
+      #b1
+      ((_ extract 0 0)
+       (bvlshr
+        op.cr
+        ((_ zero_extend 27)
+         (bvsub #b11111 op.bi)))))
+     (notp
       (bveq
        #b1
        ((_ extract 0 0)
         (bvlshr
          op.cr
          ((_ zero_extend 27)
-          (bvsub #b11111 op.bi)))))
-      (notp
-       (bveq
-        #b1
-        ((_ extract 0 0)
-         (bvlshr
-          op.cr
-          ((_ zero_extend 27)
-           (bvsub #b11111 op.bi))))))))))))
+          (bvsub #b11111 op.bi)))))))))))

--- a/semmc-ppc/data/32/manual/generic_ctr_ok.fun
+++ b/semmc-ppc/data/32/manual/generic_ctr_ok.fun
@@ -8,27 +8,22 @@
  (body
   (with
    ()
-   (let
-    ((false
-     (bveq #b0 #b0))
-     (true
-      (bveq #b0 #b0)))
+   (ite
+    (bveq
+     #b1
+     ((_ extract 0 0)
+      (bvlshr op.bo #b00010)))
+    #true
     (ite
      (bveq
       #b1
       ((_ extract 0 0)
-       (bvlshr op.bo #b00010)))
-     true
-     (ite
-      (bveq
-       #b1
-       ((_ extract 0 0)
-        (bvlshr op.bo #b00001)))
-      (xorp
-       (notp
-        (bveq op.newCtr #x00000000))
-       true)
-      (xorp
-       (notp
-        (bveq op.newCtr #x00000000))
-       false)))))))
+       (bvlshr op.bo #b00001)))
+     (xorp
+      (notp
+       (bveq op.newCtr #x00000000))
+      #true)
+     (xorp
+      (notp
+       (bveq op.newCtr #x00000000))
+      #false))))))

--- a/semmc-ppc/data/64/base/ADD4Oo.sem
+++ b/semmc-ppc/data/64/base/ADD4Oo.sem
@@ -9,20 +9,68 @@
   ((loc.CR
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (call
-      df.cmpImm
-      (bvslt
-       (bvadd op.rA op.rB)
-       #x0000000000000000)
-      (bvsgt
-       (bvadd op.rA op.rB)
-       #x0000000000000000)
-      #b000
+    (call
+     df.cmpImm
+     (bvslt
+      (bvadd op.rA op.rB)
+      #x0000000000000000)
+     (bvsgt
+      (bvadd op.rA op.rB)
+      #x0000000000000000)
+     #b000
+     (concat
+      ((_ extract 63 32)
+       (concat
+        ((_ extract 63 31)
+         loc.XER)
+        (concat
+         (ite
+          (ite
+           (andp
+            (bvslt op.rA #x0000000000000000)
+            (bvslt op.rB #x0000000000000000))
+           (notp
+            (bvslt
+             (bvadd op.rA op.rB)
+             #x0000000000000000))
+           (ite
+            (andp
+             (bvsge op.rA #x0000000000000000)
+             (bvsge op.rB #x0000000000000000))
+            (notp
+             (bvsge
+              (bvadd op.rA op.rB)
+              #x0000000000000000))
+            #false))
+          #b1
+          #b0)
+         ((_ extract 29 0)
+          loc.XER))))
       (concat
-       ((_ extract 63 32)
+       (bvor
+        ((_ extract 31 31)
+         loc.XER)
+        (ite
+         (ite
+          (andp
+           (bvslt op.rA #x0000000000000000)
+           (bvslt op.rB #x0000000000000000))
+          (notp
+           (bvslt
+            (bvadd op.rA op.rB)
+            #x0000000000000000))
+          (ite
+           (andp
+            (bvsge op.rA #x0000000000000000)
+            (bvsge op.rB #x0000000000000000))
+           (notp
+            (bvsge
+             (bvadd op.rA op.rB)
+             #x0000000000000000))
+           #false))
+         #b1
+         #b0))
+       ((_ extract 30 0)
         (concat
          ((_ extract 63 31)
           loc.XER)
@@ -44,71 +92,68 @@
               (bvsge
                (bvadd op.rA op.rB)
                #x0000000000000000))
-             false))
+             #false))
            #b1
            #b0)
           ((_ extract 29 0)
-           loc.XER))))
-       (concat
-        (bvor
-         ((_ extract 31 31)
-          loc.XER)
-         (ite
-          (ite
-           (andp
-            (bvslt op.rA #x0000000000000000)
-            (bvslt op.rB #x0000000000000000))
-           (notp
-            (bvslt
-             (bvadd op.rA op.rB)
-             #x0000000000000000))
-           (ite
-            (andp
-             (bvsge op.rA #x0000000000000000)
-             (bvsge op.rB #x0000000000000000))
-            (notp
-             (bvsge
-              (bvadd op.rA op.rB)
-              #x0000000000000000))
-            false))
-          #b1
-          #b0))
-        ((_ extract 30 0)
-         (concat
-          ((_ extract 63 31)
-           loc.XER)
-          (concat
-           (ite
-            (ite
-             (andp
-              (bvslt op.rA #x0000000000000000)
-              (bvslt op.rB #x0000000000000000))
-             (notp
-              (bvslt
-               (bvadd op.rA op.rB)
-               #x0000000000000000))
-             (ite
-              (andp
-               (bvsge op.rA #x0000000000000000)
-               (bvsge op.rB #x0000000000000000))
-              (notp
-               (bvsge
-                (bvadd op.rA op.rB)
-                #x0000000000000000))
-              false))
-            #b1
-            #b0)
-           ((_ extract 29 0)
-            loc.XER))))))
-      loc.CR))))
+           loc.XER))))))
+     loc.CR)))
    (loc.XER
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
+     (concat
+      ((_ extract 63 32)
+       (concat
+        ((_ extract 63 31)
+         loc.XER)
+        (concat
+         (ite
+          (ite
+           (andp
+            (bvslt op.rA #x0000000000000000)
+            (bvslt op.rB #x0000000000000000))
+           (notp
+            (bvslt
+             (bvadd op.rA op.rB)
+             #x0000000000000000))
+           (ite
+            (andp
+             (bvsge op.rA #x0000000000000000)
+             (bvsge op.rB #x0000000000000000))
+            (notp
+             (bvsge
+              (bvadd op.rA op.rB)
+              #x0000000000000000))
+            #false))
+          #b1
+          #b0)
+         ((_ extract 29 0)
+          loc.XER))))
       (concat
-       ((_ extract 63 32)
+       (bvor
+        ((_ extract 31 31)
+         loc.XER)
+        (ite
+         (ite
+          (andp
+           (bvslt op.rA #x0000000000000000)
+           (bvslt op.rB #x0000000000000000))
+          (notp
+           (bvslt
+            (bvadd op.rA op.rB)
+            #x0000000000000000))
+          (ite
+           (andp
+            (bvsge op.rA #x0000000000000000)
+            (bvsge op.rB #x0000000000000000))
+           (notp
+            (bvsge
+             (bvadd op.rA op.rB)
+             #x0000000000000000))
+           #false))
+         #b1
+         #b0))
+       ((_ extract 30 0)
         (concat
          ((_ extract 63 31)
           loc.XER)
@@ -130,62 +175,11 @@
               (bvsge
                (bvadd op.rA op.rB)
                #x0000000000000000))
-             false))
+             #false))
            #b1
            #b0)
           ((_ extract 29 0)
-           loc.XER))))
-       (concat
-        (bvor
-         ((_ extract 31 31)
-          loc.XER)
-         (ite
-          (ite
-           (andp
-            (bvslt op.rA #x0000000000000000)
-            (bvslt op.rB #x0000000000000000))
-           (notp
-            (bvslt
-             (bvadd op.rA op.rB)
-             #x0000000000000000))
-           (ite
-            (andp
-             (bvsge op.rA #x0000000000000000)
-             (bvsge op.rB #x0000000000000000))
-            (notp
-             (bvsge
-              (bvadd op.rA op.rB)
-              #x0000000000000000))
-            false))
-          #b1
-          #b0))
-        ((_ extract 30 0)
-         (concat
-          ((_ extract 63 31)
-           loc.XER)
-          (concat
-           (ite
-            (ite
-             (andp
-              (bvslt op.rA #x0000000000000000)
-              (bvslt op.rB #x0000000000000000))
-             (notp
-              (bvslt
-               (bvadd op.rA op.rB)
-               #x0000000000000000))
-             (ite
-              (andp
-               (bvsge op.rA #x0000000000000000)
-               (bvsge op.rB #x0000000000000000))
-              (notp
-               (bvsge
-                (bvadd op.rA op.rB)
-                #x0000000000000000))
-              false))
-            #b1
-            #b0)
-           ((_ extract 29 0)
-            loc.XER)))))))))
+           loc.XER))))))))
    (op.rT
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZ.sem
+++ b/semmc-ppc/data/64/manual/BDNZ.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       false)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZL.sem
+++ b/semmc-ppc/data/64/manual/BDNZL.sem
@@ -10,21 +10,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        false)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZLm.sem
+++ b/semmc-ppc/data/64/manual/BDNZLm.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        false)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZLp.sem
+++ b/semmc-ppc/data/64/manual/BDNZLp.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((false
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        false)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #false)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZm.sem
+++ b/semmc-ppc/data/64/manual/BDNZm.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       false)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDNZp.sem
+++ b/semmc-ppc/data/64/manual/BDNZp.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((false
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       false)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #false)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZ.sem
+++ b/semmc-ppc/data/64/manual/BDZ.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       true)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZL.sem
+++ b/semmc-ppc/data/64/manual/BDZL.sem
@@ -10,21 +10,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        true)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZLm.sem
+++ b/semmc-ppc/data/64/manual/BDZLm.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        true)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZLp.sem
+++ b/semmc-ppc/data/64/manual/BDZLp.sem
@@ -11,21 +11,18 @@
    (loc.IP
     (with
      ()
-     (let
-      ((true
-       (bveq #b0 #b0)))
-      (ite
-       (xorp
-        (notp
-         (bveq
-          (bvsub loc.CTR #x0000000000000001)
-          #x0000000000000000))
-        true)
-       (bvadd
-        ((_ sign_extend 48)
-         (concat op.target #b00))
-        loc.IP)
-       (bvadd loc.IP #x0000000000000004)))))
+     (ite
+      (xorp
+       (notp
+        (bveq
+         (bvsub loc.CTR #x0000000000000001)
+         #x0000000000000000))
+       #true)
+      (bvadd
+       ((_ sign_extend 48)
+        (concat op.target #b00))
+       loc.IP)
+      (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZm.sem
+++ b/semmc-ppc/data/64/manual/BDZm.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       true)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/BDZp.sem
+++ b/semmc-ppc/data/64/manual/BDZp.sem
@@ -7,21 +7,18 @@
   ((loc.IP
    (with
     ()
-    (let
-     ((true
-      (bveq #b0 #b0)))
-     (ite
-      (xorp
-       (notp
-        (bveq
-         (bvsub loc.CTR #x0000000000000001)
-         #x0000000000000000))
-       true)
-      (bvadd
-       ((_ sign_extend 48)
-        (concat op.target #b00))
-       loc.IP)
-      (bvadd loc.IP #x0000000000000004)))))
+    (ite
+     (xorp
+      (notp
+       (bveq
+        (bvsub loc.CTR #x0000000000000001)
+        #x0000000000000000))
+      #true)
+     (bvadd
+      ((_ sign_extend 48)
+       (concat op.target #b00))
+      loc.IP)
+     (bvadd loc.IP #x0000000000000004))))
    (loc.CTR
     (with
      ()

--- a/semmc-ppc/data/64/manual/generic_cond_ok.fun
+++ b/semmc-ppc/data/64/manual/generic_cond_ok.fun
@@ -10,32 +10,29 @@
  (body
   (with
    ()
-   (let
-    ((true
-     (bveq #b0 #b0)))
+   (ite
+    (bveq
+     #b1
+     ((_ extract 0 0)
+      (bvlshr op.bo #b00100)))
+    #true
     (ite
      (bveq
       #b1
       ((_ extract 0 0)
-       (bvlshr op.bo #b00100)))
-     true
-     (ite
-      (bveq
-       #b1
-       ((_ extract 0 0)
-        (bvlshr op.bo #b00011)))
+       (bvlshr op.bo #b00011)))
+     (bveq
+      #b1
+      ((_ extract 0 0)
+       (bvlshr
+        op.cr
+        ((_ zero_extend 27)
+         (bvsub #b11111 op.bi)))))
+     (notp
       (bveq
        #b1
        ((_ extract 0 0)
         (bvlshr
          op.cr
          ((_ zero_extend 27)
-          (bvsub #b11111 op.bi)))))
-      (notp
-       (bveq
-        #b1
-        ((_ extract 0 0)
-         (bvlshr
-          op.cr
-          ((_ zero_extend 27)
-           (bvsub #b11111 op.bi))))))))))))
+          (bvsub #b11111 op.bi)))))))))))

--- a/semmc-ppc/data/64/manual/generic_ctr_ok.fun
+++ b/semmc-ppc/data/64/manual/generic_ctr_ok.fun
@@ -8,27 +8,22 @@
  (body
   (with
    ()
-   (let
-    ((false
-     (bveq #b0 #b0))
-     (true
-      (bveq #b0 #b0)))
+   (ite
+    (bveq
+     #b1
+     ((_ extract 0 0)
+      (bvlshr op.bo #b00010)))
+    #true
     (ite
      (bveq
       #b1
       ((_ extract 0 0)
-       (bvlshr op.bo #b00010)))
-     true
-     (ite
-      (bveq
-       #b1
-       ((_ extract 0 0)
-        (bvlshr op.bo #b00001)))
-      (xorp
-       (notp
-        (bveq op.newCtr #x0000000000000000))
-       true)
-      (xorp
-       (notp
-        (bveq op.newCtr #x0000000000000000))
-       false)))))))
+       (bvlshr op.bo #b00001)))
+     (xorp
+      (notp
+       (bveq op.newCtr #x0000000000000000))
+      #true)
+     (xorp
+      (notp
+       (bveq op.newCtr #x0000000000000000))
+      #false))))))

--- a/semmc/src/SemMC/DSL.hs
+++ b/semmc/src/SemMC/DSL.hs
@@ -1324,14 +1324,7 @@ assignName serializedExpr name = do
 convertExpr :: Some Expr -> Memo SExpr
 convertExpr (Some initExpr) =
   case initExpr of
-    -- there is no atomic True or False value, so represent those as
-    -- an expression, but use the base expression form without any
-    -- possible re-evaluation to avoid recursion.
-    LitBool b -> do
-      let x = A $ ABV 1 0
-      if b
-        then assignName (L [ident "bveq", x, x]) "true"
-        else assignName (L [ident "bveq", x, x]) "false"
+    LitBool b -> return $ A $ ABool b
     LitInt i -> return $ int i
     -- We serialize the string literal `"FOO"` as the s-expression identifier
     -- `const.FOO`, so that when we're parsing the serialized s-expression


### PR DESCRIPTION
Fixes a subtle bug missed in the previous commit regarding SemMC.DSL serialization of bools that shows up in `macaw`'s `macaw-semmc-tests`.