### PR TITLE
Update semmc-arm and semmc tests to use bv-sized

### DIFF
--- a/semmc-arm/semmc-arm.cabal
+++ b/semmc-arm/semmc-arm.cabal
@@ -51,6 +51,7 @@ library
                      , mtl
                      , binary
                      , bytestring
+                     , bv-sized
                      , containers
                      , crucible
                      , dismantle-arm

--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -148,6 +148,7 @@ test-suite semmc-semstore-tests
   hs-source-dirs: tests/semstore
   build-depends: base
                , bytestring
+               , bv-sized
                , containers
                , crucible
                , directory

--- a/semmc/tests/semstore/TestArchPropGen.hs
+++ b/semmc/tests/semstore/TestArchPropGen.hs
@@ -16,6 +16,7 @@ module TestArchPropGen
 where
 
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
+import qualified Data.BitVector.Sized as BVS
 import qualified Data.Foldable as F
 import           Data.Int ( Int64 )
 import qualified Data.List as L
@@ -401,7 +402,7 @@ genBV32SymExpr sym params opvars litvars = do
       nonrecursive =
         [ -- non-recursive
           do i <- toInteger <$> HG.int32 linearBounded
-             expr <- liftIO $ WI.bvLit sym knownNat i
+             expr <- liftIO $ WI.bvLit sym knownNat (BVS.mkBV knownNat i)
              return ("bvLit32=" <> show i, expr)
         ] <> optional
 


### PR DESCRIPTION
These slipped through the cracks in the main update patch series