### PR TITLE
Adapt to GaloisInc/crucible#794

### DIFF
--- a/semmc-ppc/semmc-ppc.cabal
+++ b/semmc-ppc/semmc-ppc.cabal
@@ -158,6 +158,7 @@ executable semmc-ppc-synthdemo
                  , dismantle-tablegen
                  , dismantle-ppc
                  , crucible
+                 , crucible-llvm
                  , base16-bytestring
                  , elf-edit
                  , optparse-applicative
@@ -202,5 +203,6 @@ test-suite semmc-ppc-tests
                  tasty-hunit,
                  parameterized-utils,
                  crucible,
+                 crucible-llvm,
                  what4,
                  text

--- a/semmc-ppc/tools/SynthDemo.hs
+++ b/semmc-ppc/tools/SynthDemo.hs
@@ -30,6 +30,7 @@ import qualified Data.Parameterized.Nonce as N
 import           Data.Parameterized.Some ( Some (..) )
 import qualified Lang.Crucible.Backend as CRUB
 import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 import qualified What4.Expr.Builder as SB
 import qualified What4.ProblemFeatures as WPF
 import qualified What4.Protocol.Online as WPO
@@ -208,6 +209,7 @@ mainWith r opts = do
     -- Look for an equivalent program!
     putStrLn ""
     putStrLn "Starting synthesis..."
+    let ?memOpts = LLVM.defaultMemOptions
     newInsns <- maybe (fail "Sorry, synthesis failed") return =<< SemMC.mcSynth synthEnv formula
     putStrLn ""
     putStrLn "Here's the equivalent program:"

--- a/semmc-synthesis/src/SemMC/Synthesis.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE MonoLocalBinds #-}
 module SemMC.Synthesis
   ( setupEnvironment
@@ -22,6 +23,7 @@ import           Control.Exception.Base (finally)
 import qualified What4.Protocol.Online as WPO
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 
 import           SemMC.Architecture
 import           SemMC.Formula
@@ -66,7 +68,8 @@ setupEnvironment sym baseSet =
 mcSynth :: (TemplateConstraints arch,
             ArchRepr arch,
             WPO.OnlineSolver solver,
-            CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+            CB.IsSymInterface (CBO.OnlineBackend t solver fs),
+            ?memOpts :: LLVM.MemOptions
            )
         => SynthesisEnvironment (CBO.OnlineBackend t solver fs) arch
         -> Formula (CBO.OnlineBackend t solver fs) arch
@@ -104,9 +107,10 @@ mcSynth env target = do
 mcSynthTimeout :: (TemplateConstraints arch,
                    ArchRepr arch,
                    WPO.OnlineSolver solver,
-                   CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+                   CB.IsSymInterface (CBO.OnlineBackend t solver fs),
+                   ?memOpts :: LLVM.MemOptions
                   )
-               => Int 
+               => Int
                -> SynthesisEnvironment (CBO.OnlineBackend t solver fs) arch
                -> Formula (CBO.OnlineBackend t solver fs) arch
                -> IO (Maybe [Instruction arch])

--- a/semmc-synthesis/src/SemMC/Synthesis/Cegis/EvalFormula.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis/Cegis/EvalFormula.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RankNTypes, TypeApplications, ScopedTypeVariables, TypeFamilies,
-  DataKinds, AllowAmbiguousTypes #-}
+  DataKinds, AllowAmbiguousTypes, ImplicitParams #-}
 
 module SemMC.Synthesis.Cegis.EvalFormula
   ( LocEval
@@ -20,6 +20,7 @@ import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.TraversableF as TF
 
 import qualified Lang.Crucible.Backend as CB
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 import qualified What4.Interface as S
 import qualified What4.Expr as WE
 
@@ -31,7 +32,7 @@ import qualified SemMC.Synthesis.Template as Temp
 import qualified SemMC.Synthesis.Cegis.ReadWriteEval as RW
 import qualified SemMC.Synthesis.Cegis.Types as T
 
-    
+
 -- A data structure representing functions from locations to expressions
 data LocEval loc expr =
   LocEval { evalLoc :: forall (tp :: S.BaseType). loc tp -> IO (expr tp) }
@@ -112,6 +113,7 @@ evalFormula' sym (Formula vars defs) el = do
 simplifyReadMem' :: forall arch t st fs sym.
                 ( sym ~ WE.ExprBuilder t st fs, CB.IsSymInterface sym
                 , A.Architecture arch
+                , ?memOpts :: LLVM.MemOptions
                 )
              => sym
              -> Formula sym arch
@@ -126,6 +128,7 @@ simplifyReadMem' sym f@(Formula vars defs) (LocEval el) = do
 evalFormulaMem' :: forall arch t st fs sym.
                 ( sym ~ WE.ExprBuilder t st fs, CB.IsSymInterface sym
                 , A.Architecture arch
+                , ?memOpts :: LLVM.MemOptions
                 )
              => sym
              -> Formula sym arch
@@ -143,6 +146,7 @@ evalFormulaMem' sym f el = do
 evalFormulaMem :: forall arch t st fs sym.
                 ( sym ~ WE.ExprBuilder t st fs, CB.IsSymInterface sym
                 , A.Architecture arch
+                , ?memOpts :: LLVM.MemOptions
                 )
              => Formula sym arch
              -> L.ArchState arch (WE.Expr t)

--- a/semmc-synthesis/src/SemMC/Synthesis/Core.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis/Core.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ImplicitParams #-}
 module SemMC.Synthesis.Core
   ( synthesizeFormula
   , SynthesisEnvironment(..)
@@ -26,6 +27,7 @@ import qualified What4.Protocol.Online as WPO
 import qualified What4.Interface as S
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 
 import           SemMC.Architecture
 import           SemMC.Formula
@@ -94,7 +96,9 @@ footprintFilter target candidate =
 
 
 
-instantiate :: (TemplateConstraints arch, ArchRepr arch, WPO.OnlineSolver solver, CB.IsSymInterface (CBO.OnlineBackend t solver fs))
+instantiate :: ( TemplateConstraints arch, ArchRepr arch, WPO.OnlineSolver solver, CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+               , ?memOpts :: LLVM.MemOptions
+               )
             => CegisParams (CBO.OnlineBackend t solver fs) arch
             -> Formula (CBO.OnlineBackend t solver fs) arch
             -> [Some (TemplatedInstruction (CBO.OnlineBackend t solver fs) arch)]
@@ -140,7 +144,8 @@ synthesizeFormula' :: (Architecture arch,
                        ArchRepr arch,
                        Architecture (TemplatedArch arch),
                        WPO.OnlineSolver solver,
-                       CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+                       CB.IsSymInterface (CBO.OnlineBackend t solver fs),
+                       ?memOpts :: LLVM.MemOptions
                        )
                    => CegisParams (CBO.OnlineBackend t solver fs) arch
                    -> Formula (CBO.OnlineBackend t solver fs) arch
@@ -172,7 +177,8 @@ synthesizeFormula :: forall t solver fs arch .
                       Architecture (TemplatedArch arch),
                       Typeable arch,
                       WPO.OnlineSolver solver,
-                      CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+                      CB.IsSymInterface (CBO.OnlineBackend t solver fs),
+                      ?memOpts :: LLVM.MemOptions
                      )
                   => SynthesisParams (CBO.OnlineBackend t solver fs) arch
                   -> Formula (CBO.OnlineBackend t solver fs) arch
@@ -188,4 +194,4 @@ synthesizeFormula params target = do
                    }
 
 
-    
+

--- a/semmc-synthesis/src/SemMC/Synthesis/DivideAndConquer.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis/DivideAndConquer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,6 +24,7 @@ import qualified What4.Expr as WE
 import qualified What4.Protocol.Online as WPO
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 
 import           SemMC.Architecture
 import           SemMC.Formula
@@ -78,7 +80,8 @@ divideAndConquer :: (Architecture arch,
                      Architecture (TemplatedArch arch),
                      Typeable arch,
                      WPO.OnlineSolver solver,
-                     CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+                     CB.IsSymInterface (CBO.OnlineBackend t solver fs),
+                     ?memOpts :: LLVM.MemOptions
                      )
                  => SynthesisParams (CBO.OnlineBackend t solver fs) arch
                  -> Formula (CBO.OnlineBackend t solver fs) arch

--- a/semmc-synthesis/src/SemMC/Synthesis/Testing.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis/Testing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -13,6 +14,7 @@ import qualified Data.Parameterized.Map as MapF
 import qualified What4.Protocol.Online as WPO
 import qualified Lang.Crucible.Backend.Online as CBO
 import qualified Lang.Crucible.Backend as CB
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 
 import qualified SemMC.Architecture as A
 import qualified SemMC.Formula as SF
@@ -37,6 +39,7 @@ synthesizeAndCheck :: forall proxy arch t solver fs
                       , WPO.OnlineSolver solver
                       , SS.TemplatableOperand arch
                       , CB.IsSymInterface (CBO.OnlineBackend t solver fs)
+                      , ?memOpts :: LLVM.MemOptions
                       )
                    => proxy arch
                    -> SS.SynthesisEnvironment (CBO.OnlineBackend t solver fs) arch

--- a/semmc-toy/semmc-toy.cabal
+++ b/semmc-toy/semmc-toy.cabal
@@ -27,13 +27,14 @@ library
                      , located-base
                      , text >= 1 && < 2
                      , crucible >= 0.4
+                     , crucible-llvm
                      , dismantle-tablegen
                      , parameterized-utils >= 2.1.0 && < 2.2
                      , semmc
                      , semmc-learning
                      , semmc-synthesis
                      , what4 >= 0.4
-                     
+
 executable semmc-toy-stratify
   hs-source-dirs:      semmc-toy-stratify
   main-is:             Main.hs
@@ -68,4 +69,4 @@ test-suite semmc-toy-tests
                  , tasty-hunit
                  , async
                  , directory
-                 
+

--- a/semmc-toy/src/SemMC/Toy/Tests.hs
+++ b/semmc-toy/src/SemMC/Toy/Tests.hs
@@ -40,6 +40,7 @@ import qualified Dismantle.Instruction as D
 import           Dismantle.Tablegen.TH.Capture ( captureDictionaries )
 import qualified Lang.Crucible.Backend as SB
 import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.LLVM.MemModel as LLVM
 import qualified What4.Expr.Builder as WEB
 import qualified What4.Interface as S
 import qualified What4.ProblemFeatures as WPF
@@ -145,7 +146,7 @@ dependentFormula sym = do
                               $ MapF.empty
                    }
 
-doThing2 :: (U.HasLogCfg) => IO ()
+doThing2 :: (U.HasLogCfg, ?memOpts :: LLVM.MemOptions) => IO ()
 doThing2 = do
   Some r <- newIONonceGenerator
   CBO.withYicesOnlineBackend CBO.FloatRealRepr r CBO.NoUnsatFeatures WPF.noFeatures $ \sym -> do
@@ -171,7 +172,7 @@ doThing3 = do
   Right add <- readBinOpc sym AddRr
   putStrLn $ T.unpack $ printParameterizedFormula (HR.typeRepr AddRr) add
 
-doThing4 :: (U.HasLogCfg) => IO ()
+doThing4 :: (U.HasLogCfg, ?memOpts :: LLVM.MemOptions) => IO ()
 doThing4 = do
   Some r <- newIONonceGenerator
   CBO.withYicesOnlineBackend CBO.FloatRealRepr r CBO.NoUnsatFeatures WPF.noFeatures $ \sym -> do


### PR DESCRIPTION
GaloisInc/crucible#794 increases the number of functions that use implicit `MemOptions`, including a handful of key LLVM memory model–related functions. As a result, many parts of `semmc` need to add implicit `?memOpts` parameters to accommodate to this change.