### PR TITLE
Add `semstore.log` to `.gitignore`

### DIFF
--- a/semmc/.gitignore
+++ b/semmc/.gitignore
@@ -1,0 +1,1 @@
+/semstore.log


### PR DESCRIPTION
`semmc-semstore-tests` generates a `semstore.log` file as part of its tests, which is (presumably) not meant to be checked into version control. To prevent this file from polluting `git status`, add it to a `.gitignore` file.