### PR TITLE
Update crucible submodule, adapt to GaloisInc/crucible#906

### DIFF
--- a/semmc-synthesis/src/SemMC/Synthesis/Cegis/LLVMMem.hs
+++ b/semmc-synthesis/src/SemMC/Synthesis/Cegis/LLVMMem.hs
@@ -79,7 +79,8 @@ putImpl m = MemM $ do
 -- of size 2^w where w is the width of registers in the architecture. All values
 -- in memory are initialized to the values of an uninterpreted symbolic array.
 withMem :: forall arch sym a.
-           (A.Architecture arch, B.IsSymInterface sym)
+           ( A.Architecture arch, B.IsSymInterface sym
+           , ?memOpts :: LLVM.MemOptions )
         => sym
         -> S.SymExpr sym (A.MemType arch)
         -> (LLVM.HasPtrWidth (A.RegWidth arch) => MemM sym arch a)


### PR DESCRIPTION
Adapt the code to https://github.com/GaloisInc/crucible/pull/906. This time, only one function needs an additional `?memOpts :: MemOptions` constraint, thankfully enough.