### PR TITLE
Allow building with `hashable-1.4.*`

### DIFF
--- a/semmc/semmc.cabal
+++ b/semmc/semmc.cabal
@@ -83,7 +83,7 @@ library
                        parsec >= 3.1 && < 3.2,
                        megaparsec >= 7 && < 10,
                        mtl >= 2.2 && < 2.3,
-                       hashtables >= 1.2 && < 1.3,
+                       hashtables >= 1.2 && < 1.4,
                        transformers >= 0.5.2 && < 0.6,
                        directory,
                        unliftio-core >= 0.2 && < 0.3,


### PR DESCRIPTION
This was originally motivated by a discussion at GaloisInc/macaw#319, where this change was needed to make everything in `macaw` support `hashable-1.4.*`.